### PR TITLE
fix #20, function call in feedback message corresponds to used alias

### DIFF
--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -39,6 +39,7 @@ class State(object):
 
         self.pre_exercise_imports = None
         self.student_function_calls = None
+        self.student_imports = None
         self.solution_function_calls = None
         self.used_student_function = None
 
@@ -164,13 +165,14 @@ class State(object):
 
         if (self.student_function_calls is None):
             fp = FunctionParser()
-            fp.imports = self.pre_exercise_imports
+            fp.imports = self.pre_exercise_imports.copy()
             fp.visit(self.student_tree)
             self.student_function_calls = fp.calls
+            self.student_imports = fp.imports
 
         if (self.solution_function_calls is None):
             fp = FunctionParser()
-            fp.imports = self.pre_exercise_imports
+            fp.imports = self.pre_exercise_imports.copy()
             fp.visit(self.solution_tree)
             self.solution_function_calls = fp.calls
 

--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -39,7 +39,6 @@ class State(object):
 
         self.pre_exercise_imports = None
         self.student_function_calls = None
-        self.student_imports = None
         self.solution_function_calls = None
         self.used_student_function = None
 

--- a/pythonwhat/parsing.py
+++ b/pythonwhat/parsing.py
@@ -286,8 +286,7 @@ class FunctionParser(Parser):
         Args:
             node (ast.Call): The node which is visited.
         """
-        self.visit(
-            node.func)       # Need to visit func to start recording the current function name.
+        self.visit(node.func)       # Need to visit func to start recording the current function name.
 
         if self.current:
             if (self.current not in self.calls):

--- a/pythonwhat/test_function.py
+++ b/pythonwhat/test_function.py
@@ -37,7 +37,7 @@ def test_function(name,
         do_eval (bool): Boolean representing whether the group should be evaluated and compared or not.
           Defaults to True.
         not_called_msg (str): feedback message if the function is not called.
-        incorret_msg (str): feedback message if the arguments of the function in the solution doesn't match
+        incorrect_msg (str): feedback message if the arguments of the function in the solution doesn't match
           the one of the student.
 
     Raises:
@@ -78,6 +78,14 @@ def test_function(name,
     state.extract_function_calls()
     solution_calls = state.solution_function_calls
     student_calls = state.student_function_calls
+    student_imports = state.student_imports
+
+    # for messaging purposes: replace with original alias or import again.
+    stud_name = name
+    for (short, full) in student_imports.items():
+        if full in stud_name:
+            stud_name = stud_name.replace(full, short)
+            break
 
     if name not in state.used_student_function:
         state.used_student_function[name] = 0
@@ -93,7 +101,7 @@ def test_function(name,
         else:
             not_called_msg = FeedbackMessage("Make sure you call `${name}()`.")
 
-        not_called_msg.add_information("name", name)
+        not_called_msg.add_information("name", stud_name)
     else:
         not_called_msg = FeedbackMessage(not_called_msg)
 
@@ -165,7 +173,7 @@ def test_function(name,
             continue
 
         feedback = construct_incorrect_msg(nb_call)
-        feedback.set_information("name", name)
+        feedback.set_information("name", stud_name)
         feedback.set_information("line", lineno_student)
 
         success = True
@@ -209,7 +217,7 @@ def test_function(name,
     if not success:
         if not incorrect_msg:
             incorrect_msg = construct_incorrect_msg(nb_call)
-            incorrect_msg.set_information("name", name)
+            incorrect_msg.set_information("name", stud_name)
 
         rep.do_test(Test(incorrect_msg))
 

--- a/pythonwhat/test_function.py
+++ b/pythonwhat/test_function.py
@@ -82,10 +82,11 @@ def test_function(name,
 
     # for messaging purposes: replace with original alias or import again.
     stud_name = name
-    for (short, full) in student_imports.items():
-        if full in stud_name:
-            stud_name = stud_name.replace(full, short)
-            break
+    if "." in stud_name:
+        student_imports_rev = {v: k for k, v in student_imports.items()}
+        els = name.split(".")
+        front_part = ".".join(els[0:-1])
+        stud_name = student_imports_rev[front_part] + "." + els[-1]
 
     if name not in state.used_student_function:
         state.used_student_function[name] = 0

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -1,6 +1,15 @@
+from pythonbackend.Exercise import Exercise
+from pythonbackend import utils
+
 def get_sct_payload(output):
 	output = [out for out in output if out['type'] == 'sct']
 	if (len(output) > 0):
 		return(output[0]['payload'])
 	else:
 		return(None)
+
+def run(data):
+    exercise = Exercise(data)
+    exercise.runInit()
+    output = exercise.runSubmit(data)
+    return(get_sct_payload(output))


### PR DESCRIPTION
I also fixed a bug in the `FunctionParser`: `self.imports` was only a reference copy, not a deep copy, causing the list to persist from PEC to solution and student tree. Fixed now with the `.copy()`

This is a rather quick fix: in the future, we might want to change `test_function()` so that the SCT writer can specify the alias that's used in the solution. For example, if the solution uses:

```
import pandas as pd
x = pd.DataFrame({"a": [1, 2, 3]})
```

That you can use the SCT:

```
test_function("pd.DataFrame")
```

instead of 

```
test_function("pandas.DataFrame")
```

We have to juggle around with the aliasing and import statements anyway, so why not make it is as easy as possible for the SCT writer. 

Note: to make this backwards compatible with the courses we have currently: Launch version that supports both, change the SCTs, and then clean up the `test_function()` code to only work with the new system.