### PR TITLE
only override context if not None + tests

### DIFF
--- a/pythonwhat/sub_test.py
+++ b/pythonwhat/sub_test.py
@@ -4,8 +4,10 @@ def sub_test(state, rep, closure, subtree_student, subtree_solution, incorrect_p
                 student_context=None, solution_context=None, expand_message=""):
     if closure:
         child = state.to_child_state(subtree_student, subtree_solution)
-        child.student_context = student_context
-        child.solution_context = solution_context
+        if student_context is not None:
+            child.student_context = student_context
+        if solution_context is not None:
+            child.solution_context = solution_context
         closure()
         child.to_parent_state()
         if rep.failed_test:

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -558,7 +558,6 @@ success_msg("Excellent!")
 # report_status(name="anakin", affiliation="sith lord", status="deceased")
 #         '''
 #         sct_payload = helper.run(self.data)
-#         print(sct_payload)
 
 class TestToolbox9(unittest.TestCase):
     def test_pass(self):
@@ -715,7 +714,6 @@ report_status(name="anakin", affiliation="sith lord", status="deceased")
             "DC_SCT": '''
 def inner_test():
     test_function("print", index=1)
-
     def iter_test():
         context=[{'name':"luke", 'affiliation':"jedi", 'status':"missing"}]
         test_expression_result(context_vals = context)
@@ -735,7 +733,56 @@ test_function_definition(
         }
         self.data["DC_CODE"] = self.data["DC_SOLUTION"]
         sct_payload = helper.run(self.data)
-        print(sct_payload['message'])
+        self.assertTrue(sct_payload['correct'])
+
+class TestWiki(unittest.TestCase):
+    def test_pass(self):
+        self.data = {
+            "DC_PEC": "",
+            "DC_SOLUTION": '''
+def print_dict(my_dict):
+    for key, value in my_dict.items():
+        print(key + " - " + str(value))
+            ''',
+            "DC_SCT": '''
+def fun_body_test():
+    def for_iter_test():
+        example_dict = {'a': 2, 'b': 3}
+        test_expression_result(context_vals = [example_dict])
+    def for_body_test():
+        test_expression_output(context_vals = ['c', 3])
+    test_for_loop(for_iter = for_iter_test, body = for_body_test)
+test_function_definition('print_dict', body = fun_body_test)
+            '''
+        }
+        self.data["DC_CODE"] = self.data["DC_SOLUTION"]
+        sct_payload = helper.run(self.data)
+        self.assertTrue(sct_payload['correct'])
+
+class TestWiki2(unittest.TestCase):
+    def test_pass(self):
+        self.data = {
+            "DC_PEC": "",
+            "DC_SOLUTION": '''
+def print_dict(my_dict):
+    for key, value in my_dict.items():
+        print("total length: " + str(len(my_dict)))
+        print(key + " - " + str(value))
+            ''',
+            "DC_SCT": '''
+def fun_body_test():
+    def for_iter_test():
+        example_dict = {'a': 2, 'b': 3}
+        test_expression_result(context_vals = [example_dict])
+    def for_body_test():
+        example_dict = {'a': 2, 'b': 3}
+        test_expression_output(context_vals = ['c', 3], extra_env = {'my_dict': example_dict})
+    test_for_loop(for_iter = for_iter_test, body = for_body_test)
+test_function_definition('print_dict', body = fun_body_test)
+            '''
+        }
+        self.data["DC_CODE"] = self.data["DC_SOLUTION"]
+        sct_payload = helper.run(self.data)
         self.assertTrue(sct_payload['correct'])
 
 if __name__ == "__main__":


### PR DESCRIPTION
When a child state is created, it takes over the context variable names, stored in `student_contexta `nd `solution_context` respectively, automatically.

Inside `sub_test()`, these details were overridden, also if the sub test didn't have any new context variable names (it was `None` in that case)

Small fix in `sub_test()` so that the context variable names are only overriden if they actually exist.

Also added some tests, that would break if this fix wasn't there.