### PR TITLE
Minor task cleanup

### DIFF
--- a/pythonwhat/tasks.py
+++ b/pythonwhat/tasks.py
@@ -93,6 +93,182 @@ def getColumnsInProcess(name, process, shell):
 def isDefinedCollInProcess(name, key, process, shell):
     return key in get_env(shell.user_ns)[name]
 
+# Get the signature of a function inside the process
+
+def get_signature(name, mapped_name, signature, manual_sigs, env):
+    if isinstance(signature, str):
+        if signature in manual_sigs:
+            signature = inspect.Signature(manual_sigs[signature])
+        else:
+            raise ValueError('signature error - specified signature not found')
+
+    if signature is None:
+        # establish function
+        try:
+            fun = eval(mapped_name, env)
+        except:
+            raise ValueError("%s() was not found." % mapped_name)
+
+        # first go through manual sigs
+        # try to get signature
+        try:
+            if name in manual_sigs:
+                signature = inspect.Signature(manual_sigs[name])
+            else:
+                # it might be a method, and we have to find the general method name
+                if "." in mapped_name:
+                    els = name.split(".")
+                    try:
+                        els[0] = type(eval(els[0], env)).__name__
+                        generic_name = ".".join(els[:])
+                    except:
+                        raise ValueError('signature error - cannot convert call')
+                    if generic_name in manual_sigs:
+                        signature = inspect.Signature(manual_sigs[generic_name])
+                    else:
+                        raise ValueError('signature error - %s not in builtins' % generic_name)
+                else:
+                    raise ValueError('manual signature not found')
+        except:
+            try:
+                signature = inspect.signature(fun)
+            except:
+                raise ValueError('signature error - cannot determine signature')
+
+    return signature
+
+
+# Get the signature of a function based on an object inside the process
+@process_task
+def getSignatureInProcess(name, mapped_name, signature, manual_sigs, process, shell):
+    try:
+        return get_signature(name = name,
+                                mapped_name = mapped_name,
+                                signature = signature,
+                                manual_sigs = manual_sigs,
+                                env = get_env(shell.user_ns))
+    except:
+        return None
+
+@process_task
+def getSignatureFromObjInProcess(obj_char, process, shell):
+    try:
+        return inspect.signature(eval(obj_char, get_env(shell.user_ns)))
+    except:
+        return None
+
+
+
+## Get the output of a tree (with setting envs, pre_code and/er expr_code)
+@process_task
+def getOutputInProcess(tree, process, extra_env, context, context_vals, 
+                       pre_code, expr_code, keep_objs_in_env, 
+                       shell):
+    new_env = utils.copy_env(get_env(shell.user_ns), keep_objs_in_env)
+    if extra_env is not None:
+        new_env.update(copy.deepcopy(extra_env))
+    set_context_vals(new_env, context, context_vals)
+    try:
+        with capture_output() as out:
+            if pre_code is not None:
+                exec(pre_code, new_env)
+            if expr_code is not None:
+                exec(expr_code, new_env)
+            else:
+                exec(compile(tree, "<script>", "exec"), new_env)
+        return out[0].strip()
+    except:
+        return None
+    return process.executeTask(TaskGetOutput(**kwargs))
+
+# Get output of function call in process
+@process_task
+def getFunctionCallOutputInProcess(fun_name, arguments, process, shell):
+    try:
+        with capture_output() as out:
+            get_env(shell.user_ns)[fun_name](*arguments['args'], **arguments['kwargs'])
+        return out[0].strip()
+    except:
+        return None
+
+# Get error of function call in process
+@process_task
+def getFunctionCallErrorInProcess(fun_name, arguments, process, shell):
+    try:
+        get_env(shell.user_ns)[fun_name](*arguments['args'], **arguments['kwargs'])
+    except Exception as e:
+        return e
+    else:
+        return None
+
+# Get error of an expression tree in process
+@process_task
+def getTreeErrorInProcess(tree, process, shell):
+    try:
+        eval(compile(ast.Expression(tree), "<script>", "eval"), get_env(shell.user_ns))
+    except Exception as e:
+        return e
+    else:
+        return None
+
+
+# Stuff for test_with
+
+def context_env_update(context_list, env):
+    env_update = {}
+    context_objs = []
+    for context in context_list:
+        context_obj = eval(
+            compile(context['context_expr'], '<context_eval>', 'eval'),
+            env)
+        context_objs.append(context_obj)
+        context_obj_init = context_obj.__enter__()
+        context_keys = context['optional_vars']
+        if context_keys is None:
+            continue
+        elif len(context_keys) == 1:
+            env_update[context_keys[0]] = context_obj_init
+        else:
+            assert len(context_keys) == len(context_obj_init)
+            for (context_key, current_obj) in zip(context_keys, context_obj_init):
+                env_update[context_key] = current_obj
+    return (env_update, context_objs)
+
+
+@process_task
+def setUpNewEnvInProcess(context, process, shell):
+    shell.user_ns['__env__'] = utils.copy_env(shell.user_ns)
+    try:
+        context_env, context_objs = context_env_update(context, shell.user_ns['__env__'])
+        shell.user_ns['__env__'].update(context_env)
+        shell.user_ns['__context_obj__'] = context_objs
+        return True
+    except Exception as e:
+        return e
+
+# break down environment
+def context_objs_exit(context_objs):
+    got_error = False
+    for context_obj in context_objs:
+        try:
+            context_obj.__exit__(*([None]*3))
+        except Exception as e:
+            got_error = e
+
+    return got_error
+
+@process_task
+def breakDownNewEnvInProcess(process, shell):
+    try:
+        res = context_objs_exit(shell.user_ns['__context_obj__'])
+        del shell.user_ns['__context_obj__']
+        del shell.user_ns['__env__']
+        return res
+    except:
+        return False
+
+# Tasks that may need to serialize across processes ===========================
+
 # Get the value linked to a key of a collection in the process
 class TaskGetValue(object):
     def __init__(self, name, key, tempname):
@@ -216,93 +392,6 @@ def errored(el):
     return(isinstance(el, list) and 'backend-error' in str(el))
 
 
-# Get the signature of a function inside the process
-
-def get_signature(name, mapped_name, signature, manual_sigs, env):
-    if isinstance(signature, str):
-        if signature in manual_sigs:
-            signature = inspect.Signature(manual_sigs[signature])
-        else:
-            raise ValueError('signature error - specified signature not found')
-
-    if signature is None:
-        # establish function
-        try:
-            fun = eval(mapped_name, env)
-        except:
-            raise ValueError("%s() was not found." % mapped_name)
-
-        # first go through manual sigs
-        # try to get signature
-        try:
-            if name in manual_sigs:
-                signature = inspect.Signature(manual_sigs[name])
-            else:
-                # it might be a method, and we have to find the general method name
-                if "." in mapped_name:
-                    els = name.split(".")
-                    try:
-                        els[0] = type(eval(els[0], env)).__name__
-                        generic_name = ".".join(els[:])
-                    except:
-                        raise ValueError('signature error - cannot convert call')
-                    if generic_name in manual_sigs:
-                        signature = inspect.Signature(manual_sigs[generic_name])
-                    else:
-                        raise ValueError('signature error - %s not in builtins' % generic_name)
-                else:
-                    raise ValueError('manual signature not found')
-        except:
-            try:
-                signature = inspect.signature(fun)
-            except:
-                raise ValueError('signature error - cannot determine signature')
-
-    return signature
-
-
-# Get the signature of a function based on an object inside the process
-@process_task
-def getSignatureInProcess(name, mapped_name, signature, manual_sigs, process, shell):
-    try:
-        return get_signature(name = name,
-                                mapped_name = mapped_name,
-                                signature = signature,
-                                manual_sigs = manual_sigs,
-                                env = get_env(shell.user_ns))
-    except:
-        return None
-
-@process_task
-def getSignatureFromObjInProcess(obj_char, process, shell):
-    try:
-        return inspect.signature(eval(obj_char, get_env(shell.user_ns)))
-    except:
-        return None
-
-
-
-## Get the output of a tree (with setting envs, pre_code and/er expr_code)
-@process_task
-def getOutputInProcess(tree, process, extra_env, context, context_vals, 
-                       pre_code, expr_code, keep_objs_in_env, 
-                       shell):
-    new_env = utils.copy_env(get_env(shell.user_ns), keep_objs_in_env)
-    if extra_env is not None:
-        new_env.update(copy.deepcopy(extra_env))
-    set_context_vals(new_env, context, context_vals)
-    try:
-        with capture_output() as out:
-            if pre_code is not None:
-                exec(pre_code, new_env)
-            if expr_code is not None:
-                exec(expr_code, new_env)
-            else:
-                exec(compile(tree, "<script>", "exec"), new_env)
-        return out[0].strip()
-    except:
-        return None
-    return process.executeTask(TaskGetOutput(**kwargs))
 
 
 # Get the result of a tree (with setting envs, pre_code and/or expr_code)
@@ -392,27 +481,6 @@ def getFunctionCallResultInProcess(process, **kwargs):
         bytestream = None
     return (bytestream, strrep)
 
-# Get output of function call in process
-@process_task
-def getFunctionCallOutputInProcess(fun_name, arguments, process, shell):
-    try:
-        with capture_output() as out:
-            get_env(shell.user_ns)[fun_name](*arguments['args'], **arguments['kwargs'])
-        return out[0].strip()
-    except:
-        return None
-
-# Get error of function call in process
-@process_task
-def getFunctionCallErrorInProcess(fun_name, arguments, process, shell):
-    try:
-        get_env(shell.user_ns)[fun_name](*arguments['args'], **arguments['kwargs'])
-    except Exception as e:
-        return e
-    else:
-        return None
-
-
 # Get result of an expression tree in process
 class TaskGetTreeResult(object):
     def __init__(self, **kwargs):
@@ -435,68 +503,3 @@ def getTreeResultInProcess(process, **kwargs):
     return (bytestream, strrep)
 
 
-# Get error of an expression tree in process
-@process_task
-def getTreeErrorInProcess(tree, process, shell):
-    try:
-        eval(compile(ast.Expression(tree), "<script>", "eval"), get_env(shell.user_ns))
-    except Exception as e:
-        return e
-    else:
-        return None
-
-
-# Stuff for test_with
-
-def context_env_update(context_list, env):
-    env_update = {}
-    context_objs = []
-    for context in context_list:
-        context_obj = eval(
-            compile(context['context_expr'], '<context_eval>', 'eval'),
-            env)
-        context_objs.append(context_obj)
-        context_obj_init = context_obj.__enter__()
-        context_keys = context['optional_vars']
-        if context_keys is None:
-            continue
-        elif len(context_keys) == 1:
-            env_update[context_keys[0]] = context_obj_init
-        else:
-            assert len(context_keys) == len(context_obj_init)
-            for (context_key, current_obj) in zip(context_keys, context_obj_init):
-                env_update[context_key] = current_obj
-    return (env_update, context_objs)
-
-
-@process_task
-def setUpNewEnvInProcess(context, process, shell):
-    shell.user_ns['__env__'] = utils.copy_env(shell.user_ns)
-    try:
-        context_env, context_objs = context_env_update(context, shell.user_ns['__env__'])
-        shell.user_ns['__env__'].update(context_env)
-        shell.user_ns['__context_obj__'] = context_objs
-        return True
-    except Exception as e:
-        return e
-
-# break down environment
-def context_objs_exit(context_objs):
-    got_error = False
-    for context_obj in context_objs:
-        try:
-            context_obj.__exit__(*([None]*3))
-        except Exception as e:
-            got_error = e
-
-    return got_error
-
-@process_task
-def breakDownNewEnvInProcess(process, shell):
-    try:
-        res = context_objs_exit(shell.user_ns['__context_obj__'])
-        del shell.user_ns['__context_obj__']
-        del shell.user_ns['__env__']
-        return res
-    except:
-        return False

--- a/pythonwhat/tasks.py
+++ b/pythonwhat/tasks.py
@@ -26,7 +26,7 @@ def process_task(f):
             # unspecified, as it will be passed when the process executes
             pf = partial(wrapper, *bargs.values())
             return process.executeTask(pf)
-        # otherwise, return partialed function, that a process may be passed to
+        # otherwise, run original function
         return f(**bargs)
     return wrapper
 

--- a/pythonwhat/tasks.py
+++ b/pythonwhat/tasks.py
@@ -12,7 +12,7 @@ from contextlib import contextmanager
 from functools import partial, wraps
 
 def process_task(f):
-    """Decorator to return partial of task function if process arg not in call"""
+    """Decorator to (optionally) run function in a process."""
     sig = inspect.signature(f)
     @wraps(f)
     def wrapper(*args, **kwargs):

--- a/pythonwhat/tasks.py
+++ b/pythonwhat/tasks.py
@@ -18,10 +18,12 @@ def process_task(f):
     def wrapper(*args, **kwargs):
         # get bound arguments for call
         bargs = sig.bind_partial(*args, **kwargs).arguments
-        # when process is specified, use to execute
+        # when process is specified, remove from args and use to execute
         process = bargs.get('process')
         if process:
             bargs['process'] = None
+            # partial function since shell argument may have been left
+            # unspecified, as it will be passed when the process executes
             pf = partial(wrapper, *bargs.values())
             return process.executeTask(pf)
         # otherwise, return partialed function, that a process may be passed to


### PR DESCRIPTION
Rewrites many process tasks from being a class + function combo to decorated functions. Left cases where additional processing was being done after getting the result from the process. Note that I just pulled the code out of each class, put it in a function, and removed every case of `self.` .