### PR TITLE
Spec multi with gen, add test_not and fail SCTs

### DIFF
--- a/pythonwhat/check_funcs.py
+++ b/pythonwhat/check_funcs.py
@@ -2,6 +2,7 @@ from pythonwhat.Reporter import Reporter
 from pythonwhat.Test import Test, EqualTest
 from pythonwhat.Feedback import Feedback
 from pythonwhat.utils import get_ord
+from types import GeneratorType
 from functools import partial
 import copy
 
@@ -151,19 +152,14 @@ def multi(*args, state=None):
         rep = Reporter.active_reporter
 
         # when input is a single list of subtests
-        args = args[0] if len(args) == 1 and isinstance(args[0], (list, tuple)) else args
+        if len(args) == 1 and isinstance(args[0], (list, tuple, GeneratorType)):
+            args = args[0]
 
         for test in args:
             # assume test is function needing a state argument
             # partial state so reporter can test
-            # TODO: it seems clear the reporter doesn't need to hold state anymore
             closure = partial(test, state=state)
-            # message from parent checks
-            #prefix = state.build_message()
-            ## resetting reporter message until it can be refactored
-            #prev_msg = rep.failure_msg
             rep.do_test(closure, "", state.highlight)
-            #rep.failure_msg = prev_msg
 
     # return original state, so can be chained
     return state

--- a/pythonwhat/check_wrappers.py
+++ b/pythonwhat/check_wrappers.py
@@ -52,7 +52,7 @@ for k, v in __NODE_WRAPPERS__.items():
 
 for k in ['set_context', 
           'has_equal_value', 'has_equal_output', 'has_equal_error', 'call',
-          'extend', 'multi',
+          'extend', 'multi', 'test_not', 'fail', 'quiet',
           'with_context',
           'check_args',
           'has_equal_part']:

--- a/tests/test_instructor_warnings.py
+++ b/tests/test_instructor_warnings.py
@@ -10,5 +10,27 @@ class TestWarnings(unittest.TestCase):
         data['DC_CODE'] = data['DC_SOLUTION']
         self.assertRaises(ValueError, lambda: helper.run(data))
 
+    def test_check_syntax_double_getattr(self):
+        data = {
+                "DC_SOLUTION": "",
+                "DC_CODE": "",
+                "DC_SCT": """Ex().check_list_comp.check_body()"""
+                }
+        self.assertRaises(AttributeError, lambda: helper.run(data))
+
+    def test_check_syntax_check_index_no_index(self):
+        data = {
+                "DC_SOLUTION": "[i for i in range(1)]",
+                "DC_CODE": "[i for i in range(1)]",
+                "DC_SCT": """Ex().check_list_comp()"""
+                }
+        self.assertRaises(TypeError, lambda: helper.run(data))
+
+    def test_context_vals_wrong_place_in_chain(self):
+        data = {"DC_SOLUTION": "[(i,j) for i,j in enumerate(range(10))]"}
+        data["DC_CODE"] = data["DC_SOLUTION"]
+        data["DC_SCT"] = """Ex().check_list_comp(0).set_context(i=1,j=2).check_iter()"""
+        self.assertRaises(KeyError, lambda: helper.run(data))
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -135,7 +135,13 @@ Ex().check_list_comp(0).multi(F().check_body().set_context(aa=2).has_equal_value
         sct_payload = helper.run(self.data)
         self.assertTrue(sct_payload['correct'])
 
-
+    def test_multi_generator(self):
+        self.data["DC_SCT"] = """
+Ex().check_list_comp(0).check_body()\
+        .multi(set_context(aa=i).has_equal_value('wrong') for i in range(2))
+"""
+        sct_payload = helper.run(self.data)
+        self.assertTrue(sct_payload['correct'])
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -143,5 +143,42 @@ Ex().check_list_comp(0).check_body()\
         sct_payload = helper.run(self.data)
         self.assertTrue(sct_payload['correct'])
 
+class TestTestNot(unittest.TestCase):
+    def setUp(self):
+        self.data = {
+                "DC_SOLUTION": "x = 1",
+                "DC_CODE": "x = 1"
+                }
+
+    def test_pass(self):
+        self.data["DC_SCT"] = """Ex().test_not(check_list_comp(0), msg="no")"""
+        sct_payload = helper.run(self.data)
+        self.assertTrue(sct_payload['correct'])
+
+    def test_fail(self):
+        # obviously this would be a terrible sct...
+        self.data["DC_SCT"] = """Ex().test_not(test_object('x'), msg="no")"""
+        sct_payload = helper.run(self.data)
+        self.assertFalse(sct_payload['correct'])
+
+class TestTestFail(unittest.TestCase):
+    def setUp(self):
+        self.data = {
+                "DC_SOLUTION": "", "DC_CODE": ""
+                }
+
+    def test_fail(self):
+        self.data["DC_SCT"] = """Ex().fail()"""
+        sct_payload = helper.run(self.data)
+        self.assertFalse(sct_payload['correct'])
+
+
+#class TestSetContext(unittest.TestCase):
+#    def setUp(self):
+#        self.data = {
+#                "DC_PEC": "",
+#                "DC_SOLUTION": "[(i,j) for i,j in enumerate(range(10))]"
+#                }
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
* allows multi to be used with generator, e.g. `Ex().multi(subtest(i) for i in range(10))`
* test_not fails if all subtests pass
* `fail` fails all the time (I mean, unless it were put in a `test_not`... ;). It may be useful in the future for printing out information. address issue #34. It only looks for TestFail exceptions, so may error out sometimes due to errors raised for instructors or other SCT related errors (see issue #130).
* try to pre-empt common syntax problems and raise helpful errors (see issue #162)
