### PR TITLE
Fix test function highlight *decision needed*

### DIFF
--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -102,7 +102,7 @@ class State(object):
         self.student_context  = Context(student_context)  if student_context is None else student_context
         self.solution_context = Context(solution_context) if solution_context is None else solution_context
 
-        self.highlight = self.student_tree if highlight is None else highlight
+        self.highlight = self.student_tree if (not highlight) and self.parent_state else highlight
 
         self.converters = get_manual_converters()    # accessed only from root state
 

--- a/pythonwhat/test_funcs/test_function.py
+++ b/pythonwhat/test_funcs/test_function.py
@@ -67,8 +67,6 @@ def test_function(name,
     rep = Reporter.active_reporter
     rep.set_tag("fun", "test_function")
 
-    if not highlight: state.highlight = None
-
     index = index - 1
 
     eq_map = {"equal": EqualTest}
@@ -202,7 +200,7 @@ def test_print(index = 1,
                params_not_matched_msg="Have you correctly called `print()`?",
                params_not_specified_msg="Have you correctly called `print()`?",
                incorrect_msg="Have you printed out the correct object?",
-               highlight=True,
+               highlight=False,
                state=None):
     test_function_v2("print",
                      index=index,
@@ -262,11 +260,6 @@ def test_function_v2(name,
 
     rep = Reporter.active_reporter
     rep.set_tag("fun", "test_function")
-
-    # Note that this mutates state, which is bad. The easiest way to avoid this
-    # would be to make a copy of state, but that would break blacklisting here,
-    # which also requires state mutation.
-    if not highlight: state.highlight = None
 
     index = index - 1
     eq_map = {"equal": EqualTest}

--- a/tests/test_test_comp.py
+++ b/tests/test_test_comp.py
@@ -15,8 +15,8 @@ test_list_comp(index=1,
                iter_vars_names=True,
                incorrect_iter_vars_msg=None,
                body=lambda: test_expression_result(context_vals = ['a', 2]),
-               ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False]),
-                    lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False])],
+               ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], highlight=True),
+                    lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], highlight=True)],
                insufficient_ifs_msg=None,
                expand_message=True)
             '''
@@ -96,8 +96,8 @@ test_list_comp(index=1,
                iter_vars_names=True,
                incorrect_iter_vars_msg=None,
                body=test_expression_result(context_vals = ['a', 2]),
-               ifs=[test_function_v2('isinstance', params = ['obj'], do_eval = [False]),
-                    test_function_v2('isinstance', params = ['obj'], do_eval = [False])],
+               ifs=[test_function_v2('isinstance', params = ['obj'], do_eval = [False], highlight=True),
+                    test_function_v2('isinstance', params = ['obj'], do_eval = [False], highlight=True)],
                insufficient_ifs_msg=None,
                expand_message=True)
             '''
@@ -124,8 +124,8 @@ test_list_comp(index=1,
                iter_vars_names=True,
                incorrect_iter_vars_msg='incorrectitervars',
                body=lambda: test_expression_result(context_vals = ['a', 2], incorrect_msg = 'bodyincorrect'),
-               ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], not_called_msg = 'notcalled1', incorrect_msg = 'incorrect2'),
-                    lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], not_called_msg = 'notcalled2', incorrect_msg = 'incorrect2')],
+               ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], not_called_msg = 'notcalled1', incorrect_msg = 'incorrect2', highlight=True),
+                    lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], not_called_msg = 'notcalled2', incorrect_msg = 'incorrect2', highlight=True)],
                insufficient_ifs_msg='insufficientifs')
             '''
         }
@@ -311,7 +311,7 @@ test_dict_comp(index=1,
                incorrect_iter_vars_msg=None,
                key=lambda: test_expression_result(context_vals = ['a']),
                value=lambda: test_expression_result(context_vals = ['a']),
-               ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False])],
+               ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], highlight=True)],
                insufficient_ifs_msg=None,
                expand_message=True)
             '''
@@ -395,8 +395,8 @@ test_generator_exp(index=1,
                    iter_vars_names=True,
                    incorrect_iter_vars_msg=None,
                    body=lambda: test_expression_result(context_vals = ['a', 2]),
-                   ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False]),
-                        lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False])],
+                   ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], highlight=True),
+                        lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False], highlight=True)],
                    insufficient_ifs_msg=None,
                    expand_message=True)
             '''

--- a/tests/test_test_for_loop.py
+++ b/tests/test_test_for_loop.py
@@ -15,7 +15,7 @@ for n in range(10):
 ''',
             "DC_SCT": '''
 test_for_loop(1,
-              lambda: test_function("range"),
+              lambda: test_function("range", highlight=True),
               lambda: test_object_after_expression("size", {"size": 1}, [1]))
 success_msg("Great!")
 '''
@@ -88,7 +88,7 @@ for index, area in enumerate(areas) :
             ''',
             "DC_SCT": '''
 msg = "loopinggonewrong"
-test_for_loop(1, for_iter=lambda msg=msg: test_function("enumerate", incorrect_msg = msg))
+test_for_loop(1, for_iter=lambda msg=msg: test_function("enumerate", incorrect_msg = msg, highlight=True))
 
 msg = "blabla"
 test_for_loop(1, body=lambda msg=msg: test_expression_output(incorrect_msg = msg, context_vals = [2, "test"]))
@@ -137,7 +137,7 @@ msg = "loopinggonewrong"
 forl = Ex().check_for_loop(0)
 
 forl.check_iter()\
-    .multi(test_function("enumerate", incorrect_msg=msg))
+    .multi(test_function("enumerate", incorrect_msg=msg, highlight=True))
 
 msg = "blabla"
 forl.check_body()\
@@ -165,7 +165,7 @@ Ex().check_for_loop(0)\
         .check_for_loop(0)\
         .check_body()\
         .set_context(jj=2)\
-        .multi(test_function('sum', incorrect_msg="wronginnerfor"))
+        .multi(test_function('sum', incorrect_msg="wronginnerfor", highlight=True))
         '''
         }
 

--- a/tests/test_test_function.py
+++ b/tests/test_test_function.py
@@ -458,7 +458,7 @@ class TestLineNumbers(unittest.TestCase):
         self.data = {"DC_PEC": '',
                      "DC_SOLUTION": "round(1.23456, ndigits = 1)",
                      "DC_CODE": "round(1.34567, ndigits = 1)",
-                     "DC_SCT": "test_function('round', index = 1)"}
+                     "DC_SCT": "test_function('round', index = 1, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertIn("Did you call <code>round()</code> with the correct arguments? The first argument seems to be incorrect.", sct_payload['message'])
@@ -468,7 +468,7 @@ class TestLineNumbers(unittest.TestCase):
         self.data = {"DC_PEC": '',
                      "DC_SOLUTION": "round(1.23456, ndigits = 1)",
                      "DC_CODE": "round(1.23456, ndigits = 3)",
-                     "DC_SCT": "test_function('round', index = 1)"}
+                     "DC_SCT": "test_function('round', index = 1, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertIn("Did you call <code>round()</code> with the correct arguments? Keyword <code>ndigits</code> seems to be incorrect.", sct_payload['message'])
@@ -488,7 +488,7 @@ class TestFunctionNested(unittest.TestCase):
         self.data = {"DC_PEC": '',
                      "DC_SOLUTION": "print(type([1, 2, 3]))",
                      "DC_CODE": "print(type([1, 2, 4]))",
-                     "DC_SCT": "test_function('type')"}
+                     "DC_SCT": "test_function('type', highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         helper.test_lines(self, sct_payload, 1, 1, 12, 20)
@@ -497,7 +497,7 @@ class TestFunctionNested(unittest.TestCase):
         self.data = {"DC_PEC": '',
                      "DC_SOLUTION": "round(1.1234, ndigits = max([1, 2, 3]))",
                      "DC_CODE": "round(1.1234, ndigits = max([1, 2, 3]))",
-                     "DC_SCT": "test_function('max')"}
+                     "DC_SCT": "test_function('max', highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertTrue(sct_payload['correct'])
 
@@ -505,7 +505,7 @@ class TestFunctionNested(unittest.TestCase):
         self.data = {"DC_PEC": '',
                      "DC_SOLUTION": "round(1.1234, ndigits = max([1, 2, 3]))",
                      "DC_CODE": "round(1.1234, ndigits = max([1, 2]))",
-                     "DC_SCT": "test_function('max')"}
+                     "DC_SCT": "test_function('max', highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         helper.test_lines(self, sct_payload, 1, 1, 29, 34)
@@ -558,7 +558,7 @@ class TestFunctionDoEval(unittest.TestCase):
         self.data = {"DC_PEC": '',
              "DC_SOLUTION": "round(123.123, ndigits = 2)",
              "DC_CODE": "round(123.123)",
-             "DC_SCT": "test_function('round', do_eval = None)"}
+             "DC_SCT": "test_function('round', do_eval = None, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertEqual("Have you specified all required arguments inside <code>round()</code>?", sct_payload['message'])
@@ -568,7 +568,7 @@ class TestFunctionDoEval(unittest.TestCase):
         self.data = {"DC_PEC": '',
              "DC_SOLUTION": "round(123.123)", # args = [0]
              "DC_CODE": "round(number = 123.123)", # student args is len 0
-             "DC_SCT": "test_function('round', do_eval = None)"}
+             "DC_SCT": "test_function('round', do_eval = None, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertEqual("Have you specified all required arguments inside <code>round()</code>?", sct_payload['message'])
@@ -578,7 +578,7 @@ class TestFunctionDoEval(unittest.TestCase):
         self.data = {"DC_PEC": '',
              "DC_SOLUTION": "round(123.123, 2)", # args = [0, 1]
              "DC_CODE": "round(123.123)", # student_args is len 1
-             "DC_SCT": "test_function('round', do_eval = None)"}
+             "DC_SCT": "test_function('round', do_eval = None, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertEqual("Have you specified all required arguments inside <code>round()</code>?", sct_payload['message'])
@@ -594,9 +594,9 @@ print(123)
 print([1, 2, 3])
             ''',
              "DC_SCT": '''
-test_function("print", index = 1)
-test_function("print", index = 2)
-test_function("print", index = 3)
+test_function("print", index = 1, highlight=True)
+test_function("print", index = 2, highlight=True)
+test_function("print", index = 3, highlight=True)
             '''
         }
         self.DC_SCT_SPEC2 = '''

--- a/tests/test_test_function.py
+++ b/tests/test_test_function.py
@@ -626,6 +626,18 @@ Ex().check_function("print", 0).check_arg(0).has_equal_value()
         self.assertIn("Did you call <code>print()</code> with the correct arguments? The first argument seems to be incorrect.", sct_payload['message'])
         helper.test_lines(self, sct_payload, 1, 1, 7, 11)
 
+    def test_multiple_4_no_highlight(self):
+        self.data["DC_CODE"] = 'print("acb")\nprint(1234)\nprint([1, 2, 3])'
+        self.data["DC_SCT"] = """
+test_function("print", index = 1, highlight = False)
+test_function("print", index = 2)
+test_function("print", index = 3)
+        """
+        sct_payload = helper.run(self.data)
+        self.assertFalse(sct_payload['correct'])
+        self.assertIn("Did you call <code>print()</code> with the correct arguments? The first argument seems to be incorrect.", sct_payload['message'])
+        self.assertEqual(sct_payload.get('line_start'), None)
+
     def test_multiple_5(self):
         self.data["DC_CODE"] = 'print("abc")\nprint(1234)\nprint([1, 2, 3])'
         sct_payload = helper.run(self.data)
@@ -639,6 +651,13 @@ Ex().check_function("print", 0).check_arg(0).has_equal_value()
         self.assertFalse(sct_payload['correct'])
         self.assertIn("Did you call <code>print()</code> with the correct arguments? The first argument seems to be incorrect.", sct_payload['message'])
         helper.test_lines(self, sct_payload, 3, 3, 7, 18)
+
+    def test_nohighlight_too_few_calls(self):
+        self.data["DC_SCT"] = 'test_function("print", index = 3, args = [], keywords = [])\n' + self.data["DC_SCT"]
+        self.data["DC_CODE"] = 'print("abc")\nprint(1234)'
+        sct_payload = helper.run(self.data)
+        self.assertFalse(sct_payload['correct'])
+        self.assertEqual(sct_payload.get('line_start'), None)
 
 
 

--- a/tests/test_test_function_v2.py
+++ b/tests/test_test_function_v2.py
@@ -18,7 +18,7 @@ class TestFunctionBase(unittest.TestCase):
             "DC_PEC": "def my_fun(a):\n    pass",
             "DC_SOLUTION": "my_fun(2)",
             "DC_CODE": "my_fun(1)",
-            "DC_SCT": "test_function_v2('my_fun', params = ['a'])"
+            "DC_SCT": "test_function_v2('my_fun', params = ['a'], highlight=True)"
         }
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -40,7 +40,7 @@ class TestFunctionBase(unittest.TestCase):
             "DC_PEC": "",
             "DC_SOLUTION": "print('test')",
             "DC_CODE": "print('testing')",
-            "DC_SCT": "test_function_v2('print', params = ['value'])"
+            "DC_SCT": "test_function_v2('print', params = ['value'], highlight=True)"
         }
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -66,7 +66,7 @@ test_function_v2('max', params = ['iterable'], signature = sig)
             "DC_CODE": "max([1, 2, 3, 412])",
             "DC_SCT": '''
 sig = sig_from_params(param('iterable', param.POSITIONAL_ONLY))
-test_function_v2('max', params = ['iterable'], signature = sig)
+test_function_v2('max', params = ['iterable'], signature = sig, highlight=True)
             '''
         }
         sct_payload = helper.run(self.data)
@@ -88,7 +88,7 @@ test_function_v2('max', params = ['iterable'], signature = sig)
             "DC_PEC": "import pandas as pd",
             "DC_SOLUTION": "df = pd.DataFrame({'a': [1, 2, 3]})",
             "DC_CODE": "df = pd.DataFrame({'a': [1, 2, 312]})",
-            "DC_SCT": "test_function_v2('pandas.DataFrame', params = ['data'])"
+            "DC_SCT": "test_function_v2('pandas.DataFrame', params = ['data'], highlight=True)"
         }
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -110,7 +110,7 @@ test_function_v2('max', params = ['iterable'], signature = sig)
             "DC_PEC": "import numpy as np",
             "DC_SOLUTION": "arr = np.array([1, 2, 3])",
             "DC_CODE": "arr = np.array([1, 2, 123])",
-            "DC_SCT": "test_function_v2('numpy.array', params = ['object'])"
+            "DC_SCT": "test_function_v2('numpy.array', params = ['object'], highlight=True)"
         }
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -136,7 +136,7 @@ test_function_v2('numpy.complex', params = ['real', 'imag'], signature=sig)
             "DC_CODE": "com = np.complex(2, 5)",
             "DC_SCT": '''
 sig = sig_from_params(param('real', param.POSITIONAL_OR_KEYWORD), param('imag', param.POSITIONAL_OR_KEYWORD, default=0))
-test_function_v2('numpy.complex', params = ['real', 'imag'], signature=sig)
+test_function_v2('numpy.complex', params = ['real', 'imag'], signature=sig, highlight=True)
             '''}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -174,7 +174,7 @@ x = Test(123)
             ''',
             "DC_SOLUTION": "x.set_a(4)",
             "DC_CODE": "x.set_a(4123)",
-            "DC_SCT": "test_function_v2('x.set_a', params = ['value'])"
+            "DC_SCT": "test_function_v2('x.set_a', params = ['value'], highlight=True)"
         }
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -195,7 +195,7 @@ x = Test(123)
             "DC_PEC": "arr = [1, 2, 3, 4]",
             "DC_SOLUTION": "arr.append(5)",
             "DC_CODE": "arr.append(5123)",
-            "DC_SCT": "test_function_v2('arr.append', params = ['object'])"
+            "DC_SCT": "test_function_v2('arr.append', params = ['object'], highlight=True)"
         }
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -221,7 +221,7 @@ test_function_v2('arr.count', params = ['value'], signature=sig)
             "DC_CODE": "res = arr.count(2123)",
             "DC_SCT": '''
 sig = sig_from_params(param('value', param.POSITIONAL_ONLY))
-test_function_v2('arr.count', params = ['value'], signature=sig)
+test_function_v2('arr.count', params = ['value'], signature=sig, highlight=True)
             '''
         }
         sct_payload = helper.run(self.data)
@@ -372,7 +372,7 @@ test_function_v2('numpy.complex', params = ['real', 'imag'], signature=sig)
             "DC_PEC": "def my_fun(a):\n    pass",
             "DC_SOLUTION": "my_fun(1)",
             "DC_CODE": "my_fun(b = 1)",
-            "DC_SCT": "test_function_v2('my_fun', params = ['a'])"
+            "DC_SCT": "test_function_v2('my_fun', params = ['a'], highlight=True)"
         }
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -556,9 +556,9 @@ print(123)
 print([1, 2, 3])
             ''',
              "DC_SCT": '''
-test_function_v2("print", index = 1, params = ['value'])
-test_function_v2("print", index = 2, params = ['value'])
-test_function_v2("print", index = 3, params = ['value'])
+test_function_v2("print", index = 1, params = ['value'], highlight=True)
+test_function_v2("print", index = 2, params = ['value'], highlight=True)
+test_function_v2("print", index = 3, params = ['value'], highlight=True)
             '''
         }
     def test_multiple_1(self):
@@ -618,7 +618,7 @@ class TestStepByStep(unittest.TestCase):
         self.data = {
             "DC_PEC": "import pandas as pd",
             "DC_SOLUTION": "df = pd.DataFrame([1, 2, 3], columns=['a'])",
-            "DC_SCT": "test_function_v2('pandas.DataFrame', params=['data', 'columns'])"
+            "DC_SCT": "test_function_v2('pandas.DataFrame', params=['data', 'columns'], highlight=True)"
         }
 
     def test_step1(self):
@@ -664,7 +664,8 @@ test_function_v2('pandas.DataFrame', params=['data', 'columns'],
                  not_called_msg='notcalledmsg',
                  params_not_matched_msg='paramsnotmatchedmsg',
                  params_not_specified_msg='paramsnotspecifiedmsg',
-                 incorrect_msg='incorrectmsg')
+                 incorrect_msg='incorrectmsg',
+                 highlight=True)
             '''
         }
 
@@ -708,7 +709,8 @@ class TestStepByStepCustom2(unittest.TestCase):
             "DC_SOLUTION": "df = pd.DataFrame([1, 2, 3], columns=['a'])",
             "DC_SCT": '''
 test_function_v2('pandas.DataFrame', params=['data', 'columns'],
-                 incorrect_msg=['dataincorrect', 'columnsincorrect'])
+                 incorrect_msg=['dataincorrect', 'columnsincorrect'],
+                 highlight=True)
             '''
         }
 
@@ -738,7 +740,8 @@ class TestStepByStepCustom3(unittest.TestCase):
             "DC_SOLUTION": "df = pd.DataFrame([1, 2, 3], columns=['a'])",
             "DC_SCT": '''
 test_function_v2('pandas.DataFrame', params=['data', 'columns'],
-                 params_not_specified_msg=['datanotspecified', 'columnsnotspecified'])
+                 params_not_specified_msg=['datanotspecified', 'columnsnotspecified'],
+                 highlight=True)
             '''
         }
 
@@ -759,7 +762,7 @@ class TestStepByStepPositional(unittest.TestCase):
         self.data = {
             "DC_PEC": "x = 'test'",
             "DC_SOLUTION": "x.center(50, 't')",
-            "DC_SCT": "test_function_v2('x.center', params=['width','fillchar'])"
+            "DC_SCT": "test_function_v2('x.center', params=['width','fillchar'], highlight=True)"
         }
 
     def test_step1(self):
@@ -810,7 +813,7 @@ class TestDoEval(unittest.TestCase):
         self.data = {"DC_PEC": '',
                      "DC_SOLUTION": "round(2.1234, ndigits = 4)",
                      "DC_CODE": "round(2.123456, ndigits = 4)",
-                     "DC_SCT": "test_function_v2('round', params=['number', 'ndigits'], do_eval = True)"}
+                     "DC_SCT": "test_function_v2('round', params=['number', 'ndigits'], do_eval = True, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertIn("Did you call <code>round()</code> with the correct arguments?", sct_payload['message'])
@@ -828,7 +831,7 @@ class TestDoEval(unittest.TestCase):
         self.data = {"DC_PEC": '',
                      "DC_SOLUTION": "y = 2.12309123; round(y, ndigits = 4)",
                      "DC_CODE": "x = 2.123450; round(x, ndigits = 4)",
-                     "DC_SCT": "test_function_v2('round', params=['number', 'ndigits'], do_eval = False)"}
+                     "DC_SCT": "test_function_v2('round', params=['number', 'ndigits'], do_eval = False, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertEqual("Did you call <code>round()</code> with the correct arguments? The argument you specified for <code>number</code> seems to be incorrect.", sct_payload['message'])
@@ -846,7 +849,7 @@ class TestDoEval(unittest.TestCase):
         self.data = {"DC_PEC": '',
              "DC_SOLUTION": "round(123.123, ndigits = 2)",
              "DC_CODE": "round(123.123)",
-             "DC_SCT": "test_function_v2('round', params=['number', 'ndigits'], do_eval = None)"}
+             "DC_SCT": "test_function_v2('round', params=['number', 'ndigits'], do_eval = None, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertEqual("Have you specified all required arguments inside <code>round()</code>? You didn\'t specify <code>ndigits</code>.", sct_payload['message'])
@@ -856,7 +859,7 @@ class TestDoEval(unittest.TestCase):
         self.data = {"DC_PEC": '',
              "DC_SOLUTION": "round(123.123, 2)", # args = [0, 1]
              "DC_CODE": "round(123.123)", # student_args is len 1
-             "DC_SCT": "test_function_v2('round', params=['number', 'ndigits'], do_eval = None)"}
+             "DC_SCT": "test_function_v2('round', params=['number', 'ndigits'], do_eval = None, highlight=True)"}
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
         self.assertEqual("Have you specified all required arguments inside <code>round()</code>? You didn\'t specify <code>ndigits</code>.", sct_payload['message'])

--- a/tests/test_test_function_v2.py
+++ b/tests/test_test_function_v2.py
@@ -585,6 +585,19 @@ test_function_v2("print", index = 3, params = ['value'])
         self.assertIn("Did you call <code>print()</code> with the correct arguments?", sct_payload['message'])
         helper.test_lines(self, sct_payload, 1, 1, 7, 11)
 
+    def test_multiple_4_nohighlight(self):
+        self.data["DC_CODE"] = 'print("acb")\nprint(1234)\nprint([1, 2, 3])'
+
+        self.data["DC_SCT"] = '''
+test_function_v2("print", index = 1, params = ['value'], highlight = False)
+test_function_v2("print", index = 2, params = ['value'])
+test_function_v2("print", index = 3, params = ['value'])
+            '''
+        sct_payload = helper.run(self.data)
+        self.assertFalse(sct_payload['correct'])
+        self.assertIn("Did you call <code>print()</code> with the correct arguments?", sct_payload['message'])
+        self.assertEqual(sct_payload.get('line_start'), None)
+
     def test_multiple_5(self):
         self.data["DC_CODE"] = 'print("abc")\nprint(1234)\nprint([1, 2, 3])'
         sct_payload = helper.run(self.data)

--- a/tests/test_test_if_else.py
+++ b/tests/test_test_if_else.py
@@ -26,7 +26,7 @@ def condition_test():
 test_if_else(index=1,
              test = condition_test,
              body = lambda: test_student_typed('x\s*=\s*5', not_typed_msg = "you did something wrong"),
-             orelse = lambda: test_function('round'))
+             orelse = lambda: test_function('round', highlight=True))
 success_msg("Nice")
             '''
         }
@@ -42,7 +42,7 @@ condition_test = [
 test_if_else(index=1,
              test = condition_test,
              body = test_student_typed('x\s*=\s*5', not_typed_msg = "you did something wrong"),
-             orelse = test_function('round'))
+             orelse = test_function('round', highlight=True))
 success_msg("Nice")
             '''
 
@@ -200,7 +200,7 @@ def orelse_test():
     def body_test2():
         test_student_typed('7', not_typed_msg = 'incorrect_elif')
     def orelse_test2():
-        test_function('round')
+        test_function('round', highlight=True)
     test_if_else(index = 1,
                   test = test_test2,
                   body = body_test2,

--- a/tests/test_test_with.py
+++ b/tests/test_test_with.py
@@ -44,7 +44,7 @@ with open('moby_dick.txt') as file:
 
     def test_Fail1(self):
         self.data["DC_SCT"] = '''
-test_with(1, body = lambda: [test_function('print', index = i + 1) for i in range(3)])
+test_with(1, body = lambda: [test_function('print', index = i + 1, highlight=True) for i in range(3)])
 success_msg("Nice work!")
         '''
         sct_payload = helper.run(self.data)
@@ -55,7 +55,7 @@ success_msg("Nice work!")
 
     def test_Fail2(self):
         self.data["DC_SCT"] = '''
-test_with(1, body = lambda: [test_function('print', index = i + 1) for i in range(3)], expand_message = False)
+test_with(1, body = lambda: [test_function('print', index = i + 1, highlight=True) for i in range(3)], expand_message = False)
 success_msg("Nice work!")
         '''
         sct_payload = helper.run(self.data)
@@ -66,7 +66,7 @@ success_msg("Nice work!")
 
     def test_Pass1(self):
         self.data["DC_SCT"] = '''
-test_with(2, body = lambda: test_for_loop(1, body = lambda: test_if_else(1, body = lambda: test_function('print'))))
+test_with(2, body = lambda: test_for_loop(1, body = lambda: test_if_else(1, body = lambda: test_function('print', highlight=True))))
 success_msg("Nice work!")
         '''
         sct_payload = helper.run(self.data)
@@ -74,7 +74,7 @@ success_msg("Nice work!")
 
     def test_Fail2_no_lam(self):
         self.data["DC_SCT"] = '''
-test_with(1, body = [test_function('print', index = i + 1) for i in range(3)], expand_message = False)
+test_with(1, body = [test_function('print', index = i + 1, highlight=True) for i in range(3)], expand_message = False)
 success_msg("Nice work!")
         '''
         sct_payload = helper.run(self.data)
@@ -85,7 +85,7 @@ success_msg("Nice work!")
 
     def test_Pass1_no_lam(self):
         self.data["DC_SCT"] = '''
-test_with(2, body = test_for_loop(1, body = test_if_else(1, body = test_function('print'))))
+test_with(2, body = test_for_loop(1, body = test_if_else(1, body = test_function('print', highlight=True))))
 success_msg("Nice work!")
         '''
         sct_payload = helper.run(self.data)
@@ -93,7 +93,7 @@ success_msg("Nice work!")
 
     def test_Pass1_spec2(self):
         self.data["DC_SCT"] = '''
-for_test = test_for_loop(1, body = test_if_else(1, body = test_function('print')))
+for_test = test_for_loop(1, body = test_if_else(1, body = test_function('print', highlight=True)))
 Ex().check_with(1).check_body().with_context(for_test)
         '''
         sct_payload = helper.run(self.data)
@@ -101,7 +101,7 @@ Ex().check_with(1).check_body().with_context(for_test)
 
     def test_Fail1_spec2(self):
         self.data["DC_SCT"] = '''
-Ex().check_with(0).check_body().with_context([test_function('print', index = i+1) for i in range(3)])
+Ex().check_with(0).check_body().with_context([test_function('print', index = i+1, highlight=True) for i in range(3)])
         '''
         sct_payload = helper.run(self.data)
         self.assertFalse(sct_payload['correct'])
@@ -112,7 +112,7 @@ Ex().check_with(0).check_body().with_context([test_function('print', index = i+1
     def test_Pass1_spec2_no_ctx(self):
         self.data["DC_SCT"] = '''
 # since the print func is being tested w/o SCTs setting any variables, don't need with_context
-for_test = test_for_loop(1, body = test_if_else(1, body = test_function('print')))
+for_test = test_for_loop(1, body = test_if_else(1, body = test_function('print', highlight=True)))
 Ex().check_with(1).check_body().multi(for_test)
         '''
         sct_payload = helper.run(self.data)
@@ -232,8 +232,8 @@ success_msg("Nice work!")
     def test_Fail1(self):
         self.data["DC_SCT"] = '''
 test_with(1, context_tests=[
-    lambda: test_function('open'),
-    lambda: test_function('open')])
+    lambda: test_function('open', highlight=True),
+    lambda: test_function('open', highlight=True)])
 success_msg("Nice work!")
         '''
         sct_payload = helper.run(self.data)
@@ -244,8 +244,8 @@ success_msg("Nice work!")
     def test_Fail2(self):
         self.data["DC_SCT"] = '''
 test_with(2, context_tests=[
-    lambda: test_function('open'),
-    lambda: test_function('open')])
+    lambda: test_function('open', highlight=True),
+    lambda: test_function('open', highlight=True)])
 success_msg("Nice work!")
         '''
         sct_payload = helper.run(self.data)


### PR DESCRIPTION
Disables highlighting by default for test function, but allows it to be re-enabled by setting highlight = True in test_function[_v2]. If that doesn't sit well with you, we can always set the default to True and weigh the problem more carefully. 

The problem with highlighting when there is only 1 match, is that when there are 2 functions students should write, and they omit 1, it may highlight the wrong function. I'm not totally sold on either approach though.