### PR TITLE
func arg for has_expr for custom equality check

### DIFF
--- a/pythonwhat/Test.py
+++ b/pythonwhat/Test.py
@@ -144,16 +144,17 @@ class EqualTest(Test):
         result (bool): True if the test succeed, False if it failed. None if it hasn't been tested yet.
     """
 
-    def __init__(self, obj1, obj2, feedback):
+    def __init__(self, obj1, obj2, feedback, func = None):
         super().__init__(feedback)
         self.obj1 = obj1
         self.obj2 = obj2
+        self.func = func if func is not None else is_equal
 
     def specific_test(self):
         """
         Perform the actual test. result is set to False if the objects differ, True otherwise.
         """
-        self.result = is_equal(self.obj1, self.obj2)
+        self.result = self.func(self.obj1, self.obj2)
 
 
 

--- a/pythonwhat/check_funcs.py
+++ b/pythonwhat/check_funcs.py
@@ -485,6 +485,7 @@ def has_expr(incorrect_msg="__JINJA__:Unexpected expression {{test}}: expected `
           student and solution code. This could be thought of as post code.
         copy (bool): whether to try to deep copy objects in the environment, such as lists, that could
           accidentally be mutated. Disable to speed up SCTs. Disabling may lead to cryptic mutation issues.
+        func: custom binary function of form f(stu_result, sol_result), for equality testing.
     """
     rep = Reporter.active_reporter
 

--- a/pythonwhat/check_funcs.py
+++ b/pythonwhat/check_funcs.py
@@ -358,6 +358,7 @@ def call(args,
          error_msg=MSG_CALL_ERROR, 
          # TODO kept for backwards compatibility in test_function_definition/lambda
          argstr='',
+         func=None,
          state=None, **kwargs):
     rep = Reporter.active_reporter
     test_type = ('value', 'output', 'error')
@@ -389,7 +390,7 @@ def call(args,
 
     # incorrect result
     _msg = state.build_message(incorrect_msg, fmt_kwargs)
-    rep.do_test(EqualTest(eval_sol, eval_stu, Feedback(_msg, stu_node)))
+    rep.do_test(EqualTest(eval_sol, eval_stu, Feedback(_msg, stu_node), func))
 
     return state
 
@@ -452,6 +453,7 @@ def has_expr(incorrect_msg="__JINJA__:Unexpected expression {{test}}: expected `
              name=None,
              highlight=None,
              copy=True,
+             func=None,
              state=None,
              test=None):
     """Run student and solution code, compare returned value, printed output, or errors.
@@ -537,7 +539,7 @@ def has_expr(incorrect_msg="__JINJA__:Unexpected expression {{test}}: expected `
 
     # test equality of results
     _msg = state.build_message(incorrect_msg, fmt_kwargs)
-    rep.do_test(EqualTest(eval_stu, eval_sol, Feedback(_msg, highlight)))
+    rep.do_test(EqualTest(eval_stu, eval_sol, Feedback(_msg, highlight), func))
 
     return state
 

--- a/tests/test_test_expression_result.py
+++ b/tests/test_test_expression_result.py
@@ -41,5 +41,20 @@ class TestExpressionOutputBasic(unittest.TestCase):
         sct_payload = helper.run(self.data)
         self.assertTrue(sct_payload['correct'])
 
+    def test_test_custom_equality_func(self):
+        self.data["DC_SOLUTION"] = "a = [1.01]"
+        self.data["DC_CODE"] = "a = [1.011]"
+        self.data["DC_SCT"] = "import numpy as np; Ex().check_object('a').has_equal_value(func = lambda x, y: np.allclose(x, y, atol = .001))"
+        sct_payload = helper.run(self.data)
+        self.assertTrue(sct_payload['correct'])
+
+    def test_test_custom_equality_func_fail(self):
+        self.data["DC_SOLUTION"] = "a = [1.01]"
+        self.data["DC_CODE"] = "a = [1.011]"
+        self.data["DC_SCT"] = "import numpy as np; Ex().check_object('a').has_equal_value(func = lambda x, y: np.allclose(x, y, atol = .0001))"
+        sct_payload = helper.run(self.data)
+        self.assertFalse(sct_payload['correct'])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_test_function_definition.py
+++ b/tests/test_test_function_definition.py
@@ -30,6 +30,14 @@ eargs = {'args': ['a', 'b'], 'kwargs': {}}
 """
         self.test_step_x()
 
+    def test_step_x_spec2_func_arg(self):
+        self.data['DC_SCT'] = """
+import numpy as np
+Ex().check_function_def('test').call("f(1,2)", func = lambda x, y: np.allclose(x, y))
+                                
+"""
+        self.test_step_x()
+
 
 class TestExercise1(unittest.TestCase):
 


### PR DESCRIPTION
addresses #218 , by adding a `func` argument to SCTs like `has_equal_value`.

E.g. `Ex().check_object('x').has_equal_value(func = lambda x, y: x == y)`

Or with numpy

```
from numpy import allclose
Ex().check_object('x').has_equal_value(func = lambda x, y: allclose(x, y, atol = .01))

# or without atol option
Ex().check_object('x').has_equal_value(func = allclose)
```