### PR TITLE
Fixing minor typos while reading docs.

### DIFF
--- a/docs/articles/checking_output.rst
+++ b/docs/articles/checking_output.rst
@@ -22,7 +22,7 @@ The following SCT tests whether the student prints out ``This is some weird stuf
 
 The ``pattern`` is set to ``False`` which causes ``has_output()`` to search for the pure string.
 This SCT is not robust, because it won't be accepted if the student submits ``print("This is some cool stuff")``, for example.
-Therefore, it's a good idea to use [regular expressions](https://docs.python.org/3.5/library/re.html).
+Therefore, it's a good idea to use `regular expressions <https://docs.python.org/3.5/library/re.html>`_.
 `pattern=True` by default, so there's no need to specify this:
 
 .. code::

--- a/docs/articles/checking_through_string_matching.rst
+++ b/docs/articles/checking_through_string_matching.rst
@@ -31,7 +31,8 @@ The following SCT tests whether the student typed ``"sum(range("``:
     Ex().has_code("sum(range(", pattern = False)
 
 Notice that we set ``pattern`` to ``False``, this will cause ``has_code()`` to search for the pure string, no patterns are used.
-This SCT is not that robust though, it won't accept something like ``sum(  range(10) )``. This is why we should almost always use [regular expressions](https://docs.python.org/3.5/library/re.html) in ``has_code()``:
+This SCT is not that robust though, it won't accept something like ``sum(  range(10) )``.
+This is why we should almost always use `regular expressions <https://docs.python.org/3.5/library/re.html>`_ in ``has_code()``:
 
 .. code::
 

--- a/docs/articles/syntax.rst
+++ b/docs/articles/syntax.rst
@@ -75,7 +75,7 @@ As a more advanced example, consider the following snippet of markdown that repr
     `@sct`
     ```{python}
     Ex().check_if_else().multi(
-        check_test().has_code(/x\s+>\s+0/), # chain A
+        check_test().has_code(r'x\s+>\s+0'), # chain A
         check_body().check_function('print', 0).check_args('value').has_equal_value() # chain B
         )
     ```
@@ -169,10 +169,10 @@ Chain A will go through the same steps and will pass this time as ``x > 0`` in t
 - Finally, ``has_equal_ast()`` compares the equality of the two 'focused' arguments. They are not equal, so the check fails.
 
 
-Test vs Has?	
-============
+Check vs Has?
+=============
 
 As a general rule:
 
-- ``check_`` functions produce a child state that 'dives' deeper into a part of the state it was passed.	They are typically chained off of for further checking.	
+- ``check_`` functions produce a child state that 'dives' deeper into a part of the state it was passed. They are typically chained off of for further checking.
 - ``has_`` functions always **return the state that they were intially passed** and are used at the 'end' of a chain.


### PR DESCRIPTION
1. Using RST syntax for links to regular expression documentation (2 places).
2. Regular expression example in `syntax.md`: using `r'...'` instead of `/.../` for regular expression (please check).
3. Also in `syntax.md`: last title is "Check vs Has" instead of "Test vs Has".