### PR TITLE
Fs/check function improvements

### DIFF
--- a/docs/articles/checking_output.rst
+++ b/docs/articles/checking_output.rst
@@ -1,6 +1,9 @@
 Checking output
 ---------------
 
+Checking any output
+~~~~~~~~~~~~~~~~~~~
+
 Among the student and solution process, the student submission and solution code as a string,
 the ``Ex()`` state also contains the output that a student generated with his or her submission.
 
@@ -30,4 +33,29 @@ Therefore, it's a good idea to use `regular expressions <https://docs.python.org
     Ex().has_output(r"This is some \w* stuff",
                     no_output_msg = "Print out ``This is some ... stuff`` to the output, fill in ``...`` with a word you like.")
 
-Now, different printouts will be accepted. Notice that we also specified ``no_output_msg`` here. If the pattern is not found in the output generated, this message will be shown instead of a (typically unhelpful) message that's automatically generated.
+Now, different printouts will be accepted. Notice that we also specified ``no_output_msg`` here. If the pattern is not
+found in the output generated, this message will be shown instead of a (typically unhelpful) message that's automatically generated.
+
+Checking printouts
+~~~~~~~~~~~~~~~~~~
+
+In the past, the following SCT was used to check printouts:
+
+.. code::
+
+    Ex().check_function('print', 0).check_args(0).has_equal_value()
+
+Not only is this very tedious and long to write for something that is so common, it is also not very robust.
+``pythonwhat`` will look for the first ``print()`` call in the student code, which breaks if the student did
+another printout call before the one you're trying to test. Also, this approach requires the student to call
+the ``print()`` function in exactly the same way as the solution, although there are multiple ways.
+
+Instead, you can now use
+
+.. code::
+
+    Ex().has_printout(0)
+
+This will look for the printout in the solution code that you specified with ``index``, rerun the ``print()`` call in
+the solution process, capture its output, and verify whether the output is present in the output of the student.
+It's faster and more robust!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,12 @@ The reference docs become useful when you grasp all concepts and want to look up
    glossary
 
 .. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   reference
+
+.. toctree::
    :maxdepth: 1
    :caption: Articles
 
@@ -38,11 +44,5 @@ The reference docs become useful when you grasp all concepts and want to look up
    articles/processes.rst
    articles/electives.rst
    articles/test_to_check.rst
-
-.. toctree::
-   :maxdepth: 2
-   :caption: Reference
-
-   reference
 
 For details, questions and suggestions, `contact us <mailto:content-engineering@datacamp.com>`_.

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -6,6 +6,7 @@ Basic building blocks
 
 .. autofunction:: pythonwhat.test_funcs.test_student_typed.has_code
 .. autofunction:: pythonwhat.test_funcs.test_output_contains.has_output
+.. autofunction:: pythonwhat.test_funcs.test_output_contains.has_printout
 .. autofunction:: pythonwhat.test_funcs.test_import.has_import
 .. autofunction:: pythonwhat.check_funcs.has_equal_value
 .. autofunction:: pythonwhat.check_funcs.has_equal_error

--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -178,10 +178,6 @@ class State(object):
         for loops for example.
         """
 
-        if highlighting_disabled:
-            pass
-            # import pdb; pdb.set_trace()
-
         if isinstance(student_subtree, list):
             student_subtree = wrap_in_module(student_subtree)
         if isinstance(solution_subtree, list):

--- a/pythonwhat/check_funcs.py
+++ b/pythonwhat/check_funcs.py
@@ -473,15 +473,16 @@ def check_args(name, missing_msg='FMT:Are you sure it is defined?', state=None):
             )
 
     """
-    if name in ['*args', '**kwargs']:
+    if name in ['*args', '**kwargs']: # for check_function_def
         return check_part(name, name, state=state, missing_msg = missing_msg)
     else:
-        def build_arg_str(name):
-            return "%s argument"%get_ord(name+1) if isinstance(name, int) else "argument `%s`"%name
         if isinstance(name, list):
-            arg_str = "{} matched through the `{}`".format(build_arg_str(name[1]), name[0])
+            if name[0] == 'args':
+                arg_str = "%s argument matched to the star args"%get_ord(name[1]+1)
+            else:
+                arg_str = "argument `%s`"%name[1]
         else:
-            arg_str = build_arg_str(name)
+            arg_str = "%s argument"%get_ord(name+1) if isinstance(name, int) else "argument `%s`"%name
         return check_part_index('args', name, arg_str, state=state, missing_msg = missing_msg)
 
 

--- a/pythonwhat/check_funcs.py
+++ b/pythonwhat/check_funcs.py
@@ -478,7 +478,7 @@ def check_args(name, missing_msg='FMT:Are you sure it is defined?', state=None):
     else:
         if isinstance(name, list):
             if name[0] == 'args':
-                arg_str = "%s argument matched to the star args"%get_ord(name[1]+1)
+                arg_str = "%s argument passed as a variable length argument"%get_ord(name[1]+1)
             else:
                 arg_str = "argument `%s`"%name[1]
         else:

--- a/pythonwhat/check_funcs.py
+++ b/pythonwhat/check_funcs.py
@@ -158,7 +158,7 @@ def has_equal_part_len(name, unequal_msg, state=None):
     Arguments:
         name (str): name of the part for which to check the length to the corresponding part in the solution.
         unequal_msg (str): Message in case the lengths do not match.
-        state (State): state as passed by the SCT chain. Don't specify this.
+        state (State): state as passed by the SCT chain. Don't specify this explicitly.
 
     :Examples:
 

--- a/pythonwhat/check_wrappers.py
+++ b/pythonwhat/check_wrappers.py
@@ -4,7 +4,7 @@ from pythonwhat.check_function import check_function
 from pythonwhat.check_has_context import has_context
 from pythonwhat.test_funcs.test_data_frame import check_df
 from pythonwhat.test_funcs.test_student_typed import has_code
-from pythonwhat.test_funcs.test_output_contains import has_output
+from pythonwhat.test_funcs.test_output_contains import has_output, has_printout
 from pythonwhat.test_funcs.test_import import has_import
 
 from pythonwhat import test_funcs
@@ -75,5 +75,6 @@ for k in ['check_object', 'is_instance', 'has_equal_key', 'has_key']:
 scts['check_df'] = check_df
 scts['has_import'] = has_import
 scts['has_output'] = has_output
+scts['has_printout'] = has_printout
 scts['has_code'] = has_code
 scts['has_context'] = has_context

--- a/pythonwhat/test_funcs/test_output_contains.py
+++ b/pythonwhat/test_funcs/test_output_contains.py
@@ -1,7 +1,8 @@
 from pythonwhat.Test import StringContainsTest
 from pythonwhat.State import State
 from pythonwhat.Reporter import Reporter
-
+from pythonwhat.tasks import getOutputInProcess
+import astor
 
 def has_output(text,
                pattern=True,
@@ -32,6 +33,7 @@ def has_output(text,
 
     if not no_output_msg:
         no_output_msg = "You did not output the correct things."
+        # raise ValueError("Inside has_output(), specify the `no_output_msg` manually.")
 
     student_output = state.raw_student_output
 
@@ -46,3 +48,74 @@ def has_output(text,
     return state
 
 test_output_contains = has_output
+
+def has_printout(index,
+                 not_printed_msg="__JINJA__:Have you used `{{sol_call}}` to do the appropriate printouts?",
+                 pre_code=None,
+                 name=None,
+                 copy=False,
+                 state=None):
+    """Check if the output of print() statement in the solution is in the output the student generated.
+
+    This is more robust as ``Ex().check_function('print')`` initiated chains as students can use as many
+    printouts as they want, as long as they do the correct one somewhere.
+
+    .. note::
+
+        When zooming in on parts of the student submission (with e.g. ``check_for_loop()``), we are not
+        zooming in on the piece of the student output that is related to that piece of the student code.
+        In other words, ``has_printout()`` always considers the entire student output.
+
+    Args:
+        index (int): index of the ``print()`` call in the solution whose output you want to search for in the student output.
+        not_printed_msg (str): if specified, this overrides the default message that is generated when the output
+          is not found in the student output.
+        pre_code (str): Python code as a string that is executed before running the targeted student call.
+          This is the ideal place to set a random seed, for example.
+        copy (bool): whether to try to deep copy objects in the environment, such as lists, that could
+          accidentally be mutated. Disabled by default, which speeds up SCTs.
+        state (State): state as passed by the SCT chain. Don't specify this explicitly.
+
+    :Example:
+
+        Solution::
+
+            print(1, 2, 3, 4)
+
+        SCT::
+
+            Ex().has_printout(0)
+
+        Each of these submissions will pass::
+
+            print(1, 2, 3, 4)
+            print('1 2 3 4')
+            print(1, 2, '3 4')
+            print("random"); print(1, 2, 3, 4)
+    """
+
+
+    sol_out = state.solution_function_calls
+    try:
+        sol_call = sol_out['print'][index]['node']
+    except (KeyError, IndexError):
+        raise ValueError("Using has_printout() with index {} expects that there is/are at least {} print() call(s) in your solution."
+                         "Is that the case?".format(index, index+1))
+
+    out_sol, str_sol = getOutputInProcess(
+        tree = sol_call,
+        process = state.solution_process,
+        context = state.solution_context,
+        env = state.solution_env,
+        pre_code = pre_code,
+        copy = copy
+    )
+
+    if isinstance(str_sol, Exception):
+            raise ValueError("Evaluating expression raised error in solution process."
+                             "Error: {} - {}".format(type(str_sol), str_sol))
+
+    _msg = state.build_message(not_printed_msg, {'sol_call': astor.to_source(sol_call).strip()})
+    has_output(out_sol + '\n', pattern = False, no_output_msg=_msg, state=state)
+
+    return state

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ dill==0.2.7.1
 markdown2==2.3.5
 asttokens==1.1.10
 jinja2==2.10
+astor==0.6.2
 
 # test deps
 bs4==0.0.1

--- a/tests/test_check_function.py
+++ b/tests/test_check_function.py
@@ -82,16 +82,17 @@ def test_args_kwargs_check_function_failing_not_specified():
     with pytest.raises(TF, match=msg):
         x.check_args(['kwargs', 'c'])
 
+@pytest.mark.debug
 def test_args_kwargs_check_function_failing_not_correct():
     s = setup_state(pec = 'def my_fun(a, b, *args, **kwargs): pass',
                     sol_code = 'my_fun(1, 2, 3, 4, c = 5)',
                     stu_code = 'my_fun(1, 2, 4, 5, c = 6)')
     x = s.check_function('my_fun')
-    with pytest.raises(TF):
+    with pytest.raises(TF, match='first argument matched to the star'):
         x.check_args(['args', 0]).has_equal_value()
-    with pytest.raises(TF):
+    with pytest.raises(TF, match='second argument matched to the star'):
         x.check_args(['args', 1]).has_equal_value()
-    with pytest.raises(TF):
+    with pytest.raises(TF, match='Check the argument `c` of the'):
         x.check_args(['kwargs', 'c']).has_equal_value()
 
 def test_check_function_with_has_equal_value():

--- a/tests/test_check_function.py
+++ b/tests/test_check_function.py
@@ -88,9 +88,9 @@ def test_args_kwargs_check_function_failing_not_correct():
                     sol_code = 'my_fun(1, 2, 3, 4, c = 5)',
                     stu_code = 'my_fun(1, 2, 4, 5, c = 6)')
     x = s.check_function('my_fun')
-    with pytest.raises(TF, match='first argument matched to the star'):
+    with pytest.raises(TF, match='first argument passed as a variable length argument'):
         x.check_args(['args', 0]).has_equal_value()
-    with pytest.raises(TF, match='second argument matched to the star'):
+    with pytest.raises(TF, match='second argument passed as a variable length argument'):
         x.check_args(['args', 1]).has_equal_value()
     with pytest.raises(TF, match='Check the argument `c` of the'):
         x.check_args(['kwargs', 'c']).has_equal_value()

--- a/tests/test_has_printout.py
+++ b/tests/test_has_printout.py
@@ -14,7 +14,7 @@ def passes(st):
         "print('1 2', '3')",
         "print('1 2', 3)",
     ])
-def test_basic_check_printout_passing(stu):
+def test_basic_has_printout_passing(stu):
     sol = 'print(1, 2, 3)'
     s = setup_state(stu_code=stu, sol_code=sol)
     passes(s.has_printout(0))
@@ -28,13 +28,13 @@ def test_basic_check_printout_passing(stu):
         "print('1 2 3 4')",
         "print('1 2', 3, 4)"
     ])
-def test_basic_check_printout_failing(stu):
+def test_basic_has_printout_failing(stu):
     sol = 'print(1, 2, 3)'
     s = setup_state(stu_code=stu, sol_code=sol)
     with pytest.raises(TF, match=r'Have you used `print\(1, 2, 3\)`'):
         s.has_printout(0)
 
-def test_basic_check_printout_failing_custom():
+def test_basic_has_printout_failing_custom():
     sol = 'print(1, 2, 3)'
     stu = 'print(1, 2)'
     s = setup_state(stu_code=stu, sol_code=sol)
@@ -49,7 +49,7 @@ def test_basic_check_printout_failing_custom():
         "print('1 2', '3')",
         "print('1 2', 3)",
     ])
-def test_check_printout_multiple(stu):
+def test_has_printout_multiple(stu):
     sol = 'print("randomness")\nprint(1, 2, 3)'
     s = setup_state(stu_code=stu, sol_code=sol)
     passes(s.has_printout(1))

--- a/tests/test_has_printout.py
+++ b/tests/test_has_printout.py
@@ -1,0 +1,63 @@
+import pytest
+from pythonwhat.local import setup_state
+from pythonwhat.Test import TestFail as TF
+from pythonwhat.check_syntax import Chain
+
+def passes(st):
+    assert isinstance(st, Chain)
+
+@pytest.mark.parametrize('stu', [
+        "print(1, 2, 3)",
+        "print('1 2 3')",
+        "print('1', '2 3')",
+        "print(1, '2 3')",
+        "print('1 2', '3')",
+        "print('1 2', 3)",
+    ])
+def test_basic_check_printout_passing(stu):
+    sol = 'print(1, 2, 3)'
+    s = setup_state(stu_code=stu, sol_code=sol)
+    passes(s.has_printout(0))
+
+@pytest.mark.parametrize('stu', [
+        "print(1, 2)",
+        "print('1 2')",
+        "print('1 3 2')",
+        "print(1, 3, 2)",
+        "print(1, 2, 3, 4)",
+        "print('1 2 3 4')",
+        "print('1 2', 3, 4)"
+    ])
+def test_basic_check_printout_failing(stu):
+    sol = 'print(1, 2, 3)'
+    s = setup_state(stu_code=stu, sol_code=sol)
+    with pytest.raises(TF, match=r'Have you used `print\(1, 2, 3\)`'):
+        s.has_printout(0)
+
+def test_basic_check_printout_failing_custom():
+    sol = 'print(1, 2, 3)'
+    stu = 'print(1, 2)'
+    s = setup_state(stu_code=stu, sol_code=sol)
+    with pytest.raises(TF, match='wrong'):
+        s.has_printout(0, not_printed_msg='wrong')
+
+@pytest.mark.parametrize('stu', [
+        "print(1, 2, 3)",
+        "print('1 2 3')",
+        "print('1', '2 3')",
+        "print(1, '2 3')",
+        "print('1 2', '3')",
+        "print('1 2', 3)",
+    ])
+def test_check_printout_multiple(stu):
+    sol = 'print("randomness")\nprint(1, 2, 3)'
+    s = setup_state(stu_code=stu, sol_code=sol)
+    passes(s.has_printout(1))
+
+def test_incorrect_use():
+    s = setup_state(stu_code='', sol_code='')
+    with pytest.raises(ValueError, match='Using has_printout'):
+        s.has_printout(1)
+
+
+


### PR DESCRIPTION
This PR:

- Improves the default messaging if you use the pattern to check `*args` and `**kwargs`:
  ```
  ...check_args(['args', 0])...
  ...check_args(['kwargs', 1])...
  ```

- Adds a new function `check_print()` that is way more succinct and robust in checking whether a student did the appropriate printouts.

@sumedh10 can you let me know what you think before we merge this in? The `docs/articles/checking_output.rst` file describes the motivation behind this function. I want to see if the API feels useful to you. Thanks!