### PR TITLE
improve has_import auto-messaging

### DIFF
--- a/pythonwhat/test_funcs/test_import.py
+++ b/pythonwhat/test_funcs/test_import.py
@@ -3,10 +3,13 @@ from pythonwhat.Test import Test, DefinedCollTest, EqualTest
 from pythonwhat.State import State
 from pythonwhat.Reporter import Reporter
 
+NOT_IMPORTED_MSG = "__JINJA__:Did you import `{{pkg}}`?"
+INCORRECT_AS_MSG = "__JINJA__:Did you import `{{pkg}}` as `{{alias}}`?"
+
 def has_import(name,
                  same_as=True,
-                 not_imported_msg=None,
-                 incorrect_as_msg=None,
+                 not_imported_msg=NOT_IMPORTED_MSG,
+                 incorrect_as_msg=INCORRECT_AS_MSG,
                  state=None):
     """Check whether code has certain import statement.
 
@@ -45,24 +48,16 @@ def has_import(name,
     solution_imports = state.solution_imports
 
     if name not in solution_imports:
-        raise NameError("%r not in solution imports" % name)
+        raise NameError("The package you specified is not in the solution imports itself. %r not in solution imports" % name)
 
-    if not_imported_msg is None:
-        not_imported_msg = "Did you import `%s`?" % name
+    fmt_kwargs = { 'pkg': name, 'alias': solution_imports[name] }
 
-    _msg = state.build_message(not_imported_msg)
+    _msg = state.build_message(not_imported_msg, fmt_kwargs)
     rep.do_test(DefinedCollTest(name, student_imports, _msg))
 
     if (same_as):
-        if incorrect_as_msg is None:
-            incorrect_as_msg = "Did you set the correct alias for `%s`?" % name
-
-        _msg = state.build_message(incorrect_as_msg)
-        rep.do_test(
-            EqualTest(
-                solution_imports[name],
-                student_imports[name],
-                _msg))
+        _msg = state.build_message(incorrect_as_msg, fmt_kwargs)
+        rep.do_test(EqualTest(solution_imports[name], student_imports[name], _msg))
 
     return state
 

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -4,6 +4,7 @@ import os
 from pythonwhat.local import StubProcess
 from contextlib import redirect_stdout
 from pythonwhat.test_exercise import test_exercise
+from pythonwhat.check_syntax import Chain
 import io
 import tempfile
 
@@ -72,6 +73,9 @@ def get_sct_payload(output):
     else:
         print(output)
         return(None)
+
+def passes(st):
+    assert isinstance(st, Chain)
 
 def test_lines(test, sct_payload, ls, le, cs, ce):
     test.assertEqual(sct_payload['line_start'], ls)

--- a/tests/test_has_import.py
+++ b/tests/test_has_import.py
@@ -1,89 +1,55 @@
-import unittest
 import helper
+import pytest
+from pythonwhat.Test import TestFail as TF
+from pythonwhat.local import setup_state
 
-class TestImportingStepByStep(unittest.TestCase):
-    def setUp(self):
-        self.data = {
-            "DC_PEC": "",
-            "DC_SOLUTION": "import pandas as pd",
-            "DC_SCT": "test_import('pandas')"
-        }
+@pytest.mark.parametrize('stu, correct', [
+    ('', False),
+    ('import pandas', False),
+    ('import pandas as x', False),
+    ('import pandas as pd', True)
+])
+def test_basic(stu, correct):
+    s = setup_state(stu_code = stu, sol_code = 'import pandas as pd')
+    if correct:
+        helper.passes(s.has_import('pandas'))
+    else:
+        with pytest.raises(TF):
+            s.has_import('pandas')
 
-    def test_step_1(self):
-        self.data["DC_CODE"] = ""
-        sct_payload = helper.run(self.data)
-        self.assertFalse(sct_payload['correct'])
-        self.assertEqual(sct_payload['message'], "Did you import <code>pandas</code>?")
+@pytest.mark.parametrize('stu, same_as, correct', [
+    ('', True, False),
+    ('import pandas', True, False),
+    ('import pandas as x', True, False),
+    ('import pandas as pd', True, True),
+    ('', False, False),
+    ('import pandas', False, True),
+    ('import pandas as x', False, True),
+    ('import pandas as pd', False, True),
+])
+def test_same_as(stu, same_as, correct):
+    s = setup_state(stu_code = stu, sol_code = 'import pandas as pd')
+    if correct:
+        helper.passes(s.has_import('pandas', same_as = same_as))
+    else:
+        with pytest.raises(TF):
+            s.has_import('pandas', same_as = same_as)
 
-    def test_step_2(self):
-        self.data["DC_CODE"] = "import pandas as panda"
-        sct_payload = helper.run(self.data)
-        self.assertFalse(sct_payload['correct'])
-        self.assertEqual(sct_payload['message'], "Did you set the correct alias for <code>pandas</code>?")
+@pytest.mark.parametrize('stu, correct', [
+    ('', False),
+    ('import numpy.random', False),
+    ('import numpy.random as x', False),
+    ('import numpy.random as rand', True)
+])
+def test_chaining(stu, correct):
+    s = setup_state(stu_code = stu, sol_code = 'import numpy.random as rand')
+    if correct:
+        helper.passes(s.has_import('numpy.random'))
+    else:
+        with pytest.raises(TF):
+            s.has_import('numpy.random')
 
-    def test_step_3(self):
-        self.data["DC_CODE"] = "import pandas as pd"
-        sct_payload = helper.run(self.data)
-        self.assertTrue(sct_payload['correct'])
-
-    # if same_as = False, alias does not matter
-    def test_step_x(self):
-        self.data["DC_SCT"] = "test_import('pandas', same_as = False)"
-        self.data["DC_CODE"] = "import pandas as panda"
-        sct_payload = helper.run(self.data)
-        self.assertTrue(sct_payload['correct'])
-
-class TestImportingStepByStep(unittest.TestCase):
-    def setUp(self):
-        self.data = {
-            "DC_PEC": "",
-            "DC_SOLUTION": "import pandas as pd",
-            "DC_SCT": "Ex().has_import('pandas')"
-        }
-
-    def test_step_1(self):
-        self.data["DC_CODE"] = ""
-        sct_payload = helper.run(self.data)
-        self.assertFalse(sct_payload['correct'])
-        self.assertEqual(sct_payload['message'], "Did you import <code>pandas</code>?")
-
-    def test_step_2(self):
-        self.data["DC_CODE"] = "import pandas as panda"
-        sct_payload = helper.run(self.data)
-        self.assertFalse(sct_payload['correct'])
-        self.assertEqual(sct_payload['message'], "Did you set the correct alias for <code>pandas</code>?")
-
-    def test_step_3(self):
-        self.data["DC_CODE"] = "import pandas as pd"
-        sct_payload = helper.run(self.data)
-        self.assertTrue(sct_payload['correct'])
-
-    # if same_as = False, alias does not matter
-    def test_step_x(self):
-        self.data["DC_SCT"] = "test_import('pandas', same_as = False)"
-        self.data["DC_CODE"] = "import pandas as panda"
-        sct_payload = helper.run(self.data)
-        self.assertTrue(sct_payload['correct'])
-
-class TestImportingStepByStepCustom(unittest.TestCase):
-    def setUp(self):
-        self.data = {
-            "DC_PEC": "",
-            "DC_SOLUTION": "import pandas as pd",
-            "DC_SCT": "test_import('pandas', not_imported_msg = 'notimported', incorrect_as_msg = 'incorrectalias')"
-        }
-
-    def test_step_1(self):
-        self.data["DC_CODE"] = ""
-        sct_payload = helper.run(self.data)
-        self.assertFalse(sct_payload['correct'])
-        self.assertEqual(sct_payload['message'], "notimported")
-
-    def test_step_2(self):
-        self.data["DC_CODE"] = "import pandas as panda"
-        sct_payload = helper.run(self.data)
-        self.assertFalse(sct_payload['correct'])
-        self.assertEqual(sct_payload['message'], "incorrectalias")
-
-if __name__ == "__main__":
-    unittest.main()
+def test_wrong_usage():
+    s = setup_state(stu_code = '', sol_code = '')
+    with pytest.raises(NameError):
+        s.has_import('numpy')

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -230,3 +230,33 @@ def test_check_call_lambda(stu, patt):
     })
     assert not output['correct']
     assert message(output, patt)
+
+## has_import -----------------------------------------------------------------
+
+@pytest.mark.parametrize('stu, patt', [
+    ('', 'Did you import `pandas`?'),
+    ('import pandas', 'Did you import `pandas` as `pd`?'),
+    ('import pandas as pan', 'Did you import `pandas` as `pd`?')
+])
+def test_has_import(stu, patt):
+    output = helper.run({
+        'DC_CODE': stu,
+        'DC_SOLUTION': 'import pandas as pd',
+        'DC_SCT': "Ex().has_import('pandas')"
+    })
+    assert not output['correct']
+    assert message(output, patt)
+
+@pytest.mark.parametrize('stu, patt', [
+    ('', 'wrong'),
+    ('import pandas', 'wrongas'),
+    ('import pandas as pan', 'wrongas')
+])
+def test_has_import_custom(stu, patt):
+    output = helper.run({
+        'DC_CODE': stu,
+        'DC_SOLUTION': 'import pandas as pd',
+        'DC_SCT': "Ex().has_import('pandas', not_imported_msg='wrong', incorrect_as_msg='wrongas')"
+    })
+    assert not output['correct']
+    assert message(output, patt)


### PR DESCRIPTION
- Refer to alias when the alias is not correct
- Convert tests for has_import to use pytest
- Explicit messaging tests in tests/test_messages.py

Fixes #301 

@sumedh10 let me know if anything in here sounds completely ridiculous; otherwise I'll merge in!