### PR TITLE
Remove call, has_key and has_equal_key from API

### DIFF
--- a/pythonwhat/check_object.py
+++ b/pythonwhat/check_object.py
@@ -114,7 +114,7 @@ def check_df(index, missing_msg=None, not_instance_msg=None, expand_msg=None, st
     is_instance(pd.DataFrame, not_instance_msg=not_instance_msg, state=child)
     return child
 
-def check_keys(key, key_missing_msg=None, expand_msg=None, state=None):
+def check_keys(key, missing_msg=None, expand_msg=None, state=None):
     """Check whether an object (dict, DataFrame, etc) has a key.
 
     ``check_keys()`` can currently only be used when chained from ``check_object()``, the function that is
@@ -122,7 +122,7 @@ def check_keys(key, key_missing_msg=None, expand_msg=None, state=None):
 
     Args:
         key (str): Name of the key that the object should have.
-        key_missing_msg (str): When specified, this overrides the automatically generated
+        missing_msg (str): When specified, this overrides the automatically generated
             message in case the key does not exist.
         state (State): The state that is passed in through the SCT chain (don't specify this).
 
@@ -142,8 +142,8 @@ def check_keys(key, key_missing_msg=None, expand_msg=None, state=None):
 
     """
 
-    if key_missing_msg is None:
-        key_missing_msg = "__JINJA__:There is no {{ 'column' if 'DataFrame' in parent.typestr else 'key' }} `'{{key}}'`."
+    if missing_msg is None:
+        missing_msg = "__JINJA__:There is no {{ 'column' if 'DataFrame' in parent.typestr else 'key' }} `'{{key}}'`."
     if expand_msg is None:
         expand_msg = "__JINJA__:Did you correctly set the {{ 'column' if 'DataFrame' in parent.typestr else 'key' }} `'{{key}}'`? "
 
@@ -156,7 +156,7 @@ def check_keys(key, key_missing_msg=None, expand_msg=None, state=None):
         raise NameError("Not all keys you specified are actually keys in %s in the solution process" % sol_name)
 
     # check if key available
-    _msg = state.build_message(key_missing_msg, {'key': key})
+    _msg = state.build_message(missing_msg, {'key': key})
     rep.do_test(DefinedCollProcessTest(stu_name, key, state.student_process, 
                                        Feedback(_msg, state)))
 
@@ -179,10 +179,3 @@ def check_keys(key, key_missing_msg=None, expand_msg=None, state=None):
     append_message = {'msg': expand_msg, 'kwargs': {'key': key }}
     child = part_to_child(stu_part, sol_part, append_message, state)
     return child
-
-has_key = check_keys
-
-def has_equal_key(key, incorrect_value_msg=None, key_missing_msg=None, state=None):
-    s1 = check_keys(key, key_missing_msg=key_missing_msg, state=state)
-    s2 = has_equal_value(incorrect_msg=incorrect_value_msg, state = s1)
-    return s2

--- a/pythonwhat/check_wrappers.py
+++ b/pythonwhat/check_wrappers.py
@@ -65,7 +65,7 @@ for k in ['has_equal_value', 'has_equal_output', 'has_equal_error', 'has_equal_a
     scts[k] = getattr(has_funcs, k)
 
 # include check_object and friends ------
-for k in ['check_object', 'is_instance', 'check_df', 'check_keys', 'has_equal_key', 'has_key']:
+for k in ['check_object', 'is_instance', 'check_df', 'check_keys']:
     scts[k] = getattr(check_object, k)
 
 scts['has_context'] = has_context

--- a/pythonwhat/check_wrappers.py
+++ b/pythonwhat/check_wrappers.py
@@ -57,7 +57,7 @@ for k, v in __NODE_WRAPPERS__.items():
 for k in ['set_context', 'set_env', 'disable_highlighting', 'check_not', 'check_or', 'check_correct', 'fail', 'quiet', 'override', 'multi']:
     scts[k] = getattr(check_logic, k)
 
-for k in ['call', 'with_context', 'check_args', 'check_call']:
+for k in ['with_context', 'check_args', 'check_call']:
     scts[k] = getattr(check_funcs, k)
 
 for k in ['has_equal_value', 'has_equal_output', 'has_equal_error', 'has_equal_ast', 'has_equal_part_len',

--- a/pythonwhat/test_funcs/test_object.py
+++ b/pythonwhat/test_funcs/test_object.py
@@ -37,5 +37,5 @@ def test_data_frame(name,
             raise ValueError("Something went wrong in figuring out the columns for %s in the solution process" % name)
 
     for col in columns:
-        colstate = check_keys(col, undefined_cols_msg, state=child)
+        colstate = check_keys(col, missing_msg=undefined_cols_msg, state=child)
         has_equal_value(incorrect_msg=incorrect_msg, state=colstate)

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -225,35 +225,6 @@ Ex().check_object('x', missing_msg='objectnotdefined').has_equal_value('objectin
 
 # Check call ------------------------------------------------------------------
 
-@pytest.mark.parametrize('stu, patt', [
-    ('', 'The system wants to check the definition of `test()` but hasn\'t found it.'),
-    ('def test(a, b): return 1', 'Check the definition of `test()`. Calling `test(1, 2)` should return `3`, instead got `1`.'),
-    ('def test(a, b): return a + b', 'Check the definition of `test()`. Calling `test(1, 2)` should print out `3`, instead got no printouts.'),
-    ('''
-def test(a, b):
-    if a == 3:
-        raise ValueError('wrong')
-    print(a + b)
-    return a + b
-''', 'Check the definition of `test()`. Calling `test(3, 1)` should return `4`, instead it errored out: `wrong`.'),
-    ('def test(a, b): print(int(a) + int(b)); return int(a) + int(b)', 'Check the definition of `test()`. Calling `test(1, \'2\')` should error out with the message `unsupported operand type(s) for +: \'int\' and \'str\'`, instead got `3`.'),
-])
-def test_call(stu, patt):
-    output = helper.run({
-        'DC_CODE': stu,
-        'DC_SOLUTION': 'def test(a, b): print(a + b); return a + b',
-        'DC_SCT': """
-Ex().check_function_def('test').multi(
-    call([1, 2], 'value'),
-    call([1, 2], 'output'),
-    call([3, 1], 'value'),
-    call([1, "2"], 'error')
-)
-        """
-    })
-    assert not output['correct']
-    assert message(output, patt)
-
 @pytest.mark.debug
 @pytest.mark.parametrize('stu, patt', [
     ('', 'The system wants to check the definition of `test()` but hasn\'t found it.'),
@@ -279,18 +250,6 @@ Ex().check_function_def('test').multi(
     check_call('f(3, 1)').has_equal_value(),
     check_call('f(1, "2")').has_equal_error()
 )"""
-    })
-    assert not output['correct']
-    assert message(output, patt)
-
-@pytest.mark.parametrize('stu, patt', [
-    ('echo_word = (lambda word1, echo: word1 * echo * 2)', "Check the first lambda function. Calling it with the arguments `('test', 2)` should return `testtest`, instead got `testtesttesttest`.")
-])
-def test_call_lambda(stu, patt):
-    output = helper.run({
-        'DC_SOLUTION': 'echo_word = (lambda word1, echo: word1 * echo)',
-        'DC_CODE': stu,
-        'DC_SCT': "Ex().check_lambda_function().call(['test', 2], 'value')"
     })
     assert not output['correct']
     assert message(output, patt)

--- a/tests/test_test_function_definition.py
+++ b/tests/test_test_function_definition.py
@@ -18,23 +18,21 @@ class TestFunctionDefinitionStepByStep(unittest.TestCase):
     def test_step_x(self):
         pass
 
-    def test_step_x_spec2(self):
-        self.data['DC_SCT'] = """
-cargs = {'args': [2, 3], 'kwargs': {}}
-eargs = {'args': ['a', 'b'], 'kwargs': {}}
-(Ex().check_function_def('test').call(cargs, 'value').call(cargs, 'output').call(eargs, 'error'))
-        """
-
     def test_step_x_spec2_str_call(self):
         self.data['DC_SCT'] = """
-(Ex().check_function_def('test').call("f(1,2)", 'value').call("f(1,2)", 'output')
-                                .call("f('a','b')", 'error'))
+Ex().check_function_def('test').multi(
+    check_call("f(1,2)").multi(
+        has_equal_value(),
+        has_equal_output()
+    ),
+    check_call("f('a','b')").has_equal_error()
+)
 """
 
     def test_step_x_spec2_func_arg(self):
         self.data['DC_SCT'] = """
 import numpy as np
-Ex().check_function_def('test').call("f(1,2)", func = lambda x, y: np.allclose(x, y))
+Ex().check_function_def('test').check_call("f(1,2)").has_equal_value(func = lambda x, y: np.allclose(x, y))
 """
 
 
@@ -819,11 +817,7 @@ Ex().check_function_def('my_fun').multi(test_names)
         self.assertFalse(self.when_replace('y = 4', 'y = 2'))
 
     def test_pass_call_str(self):
-        self.data['DC_SCT'] = self.SCT_CHECK + """.call("f(1, 2, (3,4), 5, kw_arg='ok')")"""
-        self.assertTrue(self.when_replace('x', 'x2'))
-
-    def test_pass_call_list(self):
-        self.data['DC_SCT'] = self.SCT_CHECK + """.call([1, 2, (3,4), 5])"""
+        self.data['DC_SCT'] = self.SCT_CHECK + """.check_call("f(1, 2, (3,4), 5, kw_arg='ok')")"""
         self.assertTrue(self.when_replace('x', 'x2'))
 
     @unittest.skip("Tries to evaluate ast tree but gets None when no default")

--- a/tests/test_test_object.py
+++ b/tests/test_test_object.py
@@ -70,12 +70,12 @@ def test_is_instance(stu_code, passes):
 import pandas as pd
 Ex().check_object('df', missing_msg='udm', expand_msg='').\
      is_instance(pd.DataFrame, not_instance_msg='ndfm').\
-     has_equal_key('a', key_missing_msg='ucm', incorrect_value_msg='icm')
+     check_keys('a', missing_msg='ucm').has_equal_value(incorrect_msg='icm')
     """,
     """
 import pandas as pd
 Ex().check_df('df', missing_msg='udm', expand_msg='', not_instance_msg='ndfm').\
-     has_equal_key('a', key_missing_msg='ucm', incorrect_value_msg='icm')
+     check_keys('a', missing_msg='ucm').has_equal_value(incorrect_msg='icm')
     """
 ])
 @pytest.mark.parametrize('stu_code, passes, msg', [


### PR DESCRIPTION
All content has been updated to no longer use these functions, so can be safely removed.