### PR TITLE
Fs/solution overrides

### DIFF
--- a/docs/articles/single_process_exercise.rst
+++ b/docs/articles/single_process_exercise.rst
@@ -1,0 +1,106 @@
+SingleProcessExercise
+---------------------
+
+Introduction
+============
+
+Typical interactive exercises on DataCamp will be of the type ``NormalExercise`` or something similar.
+
+For these normal exercises, the pythonbackend (the Python package responsible
+for running Python code that the student submitted) will execute:
+
+- the solution code in a solution process
+  (once, at exercise initialization),
+- the student's submission in a student process
+  (every time the student hits submit, after which the process is restarted from scratch)
+- the student's experimentation commands in the console in a console process
+  (every time the user executes a command, without restarting afterwards)
+
+These completely separate processes make sure that:
+
+- the different commands do not interfere with one another;
+  if you import a package in one process,
+  the package will not become available in the other process.
+- pythonwhat has access to a 'target solution process' to easily do comparisons;
+  to compare an object ``x``, you simply have to use ``Ex().check_object('x').has_equal_value()`` and
+  pythonwhat will figure out the value ``x`` should have from the solution process.
+
+To learn more about how the backend works, you can visit
+`this wiki article <https://github.com/datacamp/pythonbackend/wiki>`_.
+
+Why does this exercise type exist?
+==================================
+
+There are Python courses that make extensive use of programs running outside of Python.
+Sometimes, these programs cannot handle it well when different
+Python process are trying to interface with it.
+An example of this is PySpark, where on container startup,
+a Spark cluster is started up, that you can then interface with.
+Things go horribly wrong if you try to access this PySpark cluster from different Python processes.
+
+To solve for this, a new exercise type was built,
+that does not create three separate Python processes (solution, student, console).
+Instead, only one process is created:
+
+- the solution code is not executed in this process.
+- the student's sumission is executed in this process, but the process is not restarted afterwards
+- the student's experimentation commands in the console are executed in the same process.
+
+From a user perspective, this shouldn't pose too much difficulties,
+with the exception that the code execution is now stateful.
+
+So, what's the problem then?
+============================
+
+As mentioned earlier, pythonwhat depends heavily on the existence of
+two separate process: a 'target' solution process, and a student process.
+Functions such as ```has_equal_value()`` compare values and the results of expression in these processes.
+In the ``SingleProcessExercise``, the student process and
+the solution process are identical, it's one and the same process,
+so these comparisons don't make any sense.
+
+Therefore, the 'process-based checks' in pythonwhat have to be used with care when
+writing SCTs for a ``SingleProcessExercise``. More specifically:
+
+- ``check_object()`` should work okay, as there is some magic happening behind the scenes.
+- ``has_equal_value()`` and ``has_equal_output()`` should be used with the ``override`` argument.
+  When this argument is specified, the expression that is 'zoomed in on' in the solution code will not be executed in the solution proces.
+  Instead, it will just take the value you pass to ``override`` to compare the result/output of the expression that is zoomed in on in the student code to.
+
+Example
+=======
+
+As an example, suppose we want to check whether a student correctly created a list ``x``:
+
+.. code::
+
+    # solution
+    x = [1, 2, 3, 4, 5]
+
+If this solution were part of a traditional ``NormalExercise``, your SCT would be simple:
+
+.. code::
+
+    # SCT
+    Ex().check_object('x').has_equal_value()
+
+However, if this solution were part of a ``SingleProcessExercise``, the above SCT would not work.
+Instead, you'll want to do the following:
+
+.. code::
+
+    # SCT
+    Ex().check_object('x').has_equal_value(override = [1, 2, 3, 4, 5])
+
+Here, we use ``override`` to tell pythonwhat not to go look for the value of ``x`` in the solution process.
+Instead, it uses the manually specified value in ``override`` to compare to.
+
+You can use ``override`` in combination with other arguments in ``has_equal_x()``, such as ``expr_code``.
+Suppose you're only interested in the element at index 2 of the list ``x``:
+
+.. code::
+
+    # SCT
+    Ex().check_object('x').has_equal_value(expr_code = 'x[2]', override = 3)
+
+Tricky stuff, but it works!

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -44,6 +44,7 @@ The reference docs become useful when you grasp all concepts and want to look up
    articles/checking_compound_statements.rst
    articles/expression_tests.rst
    articles/processes.rst
+   articles/single_process_exercise.rst
    articles/electives.rst
    articles/test_to_check.rst
 

--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -211,6 +211,14 @@ class State(object):
             setattr(child, k, v)
         return child
 
+    def has_different_processes(self):
+        # process classes have an _identity field that is a tuple
+        try:
+            return self.student_process._identity[0] != self.solution_process._identity[0]
+        except:
+            # play it safe (most common)
+            return True
+
     @staticmethod
     def parse_external(x):
         rep = Reporter.active_reporter

--- a/pythonwhat/check_object.py
+++ b/pythonwhat/check_object.py
@@ -17,7 +17,7 @@ def check_object(index, missing_msg=None, expand_msg=None, state=None, typestr="
     Args:
         index (str): the name of the object which value has to be checked.
         missing_msg (str): feedback message when the object is not defined in the student's environment.
-        expect_msg (str): prepending message to put in front.
+        expand_msg (str): prepending message to put in front.
 
     :Example:
 
@@ -49,7 +49,7 @@ def check_object(index, missing_msg=None, expand_msg=None, state=None, typestr="
 
     rep = Reporter.active_reporter
 
-    if not isDefinedInProcess(index, state.solution_process):
+    if not isDefinedInProcess(index, state.solution_process) and state.has_different_processes():
         raise NameError("%r not in solution environment " % index)
 
     append_message = {'msg': expand_msg, 'kwargs': {'index': index, 'typestr': typestr}}

--- a/pythonwhat/local.py
+++ b/pythonwhat/local.py
@@ -1,4 +1,6 @@
 import io
+import random
+
 from pythonwhat.check_syntax import Ex
 from pythonwhat.State import State
 from pythonwhat.Reporter import Reporter
@@ -16,21 +18,22 @@ class StubShell(object):
 
 class StubProcess(object):
 
-    def __init__(self, init_code = None):
+    def __init__(self, init_code = None, pid = None):
         self.shell = StubShell(init_code)
+        self._identity = (pid,) if pid else (random.randint(0, 1e12),)
 
     def executeTask(self, task):
         return task(self.shell)
 
-def setup_state(stu_code = "", sol_code = "", pec = ""):
+def setup_state(stu_code = "", sol_code = "", pec = "", pid = None):
 
     stu_output = io.StringIO()
     with redirect_stdout(stu_output):
-        stu_process = StubProcess(init_code =  "%s\n%s" % (pec, stu_code))
+        stu_process = StubProcess("%s\n%s" % (pec, stu_code), pid)
 
     sol_output = io.StringIO()
     with redirect_stdout(sol_output):
-        sol_process = StubProcess(init_code =  "%s\n%s" % (pec, sol_code))
+        sol_process = StubProcess("%s\n%s" % (pec, sol_code), pid)
 
     rep = Reporter()
     Reporter.active_reporter = rep

--- a/pythonwhat/tasks.py
+++ b/pythonwhat/tasks.py
@@ -315,14 +315,12 @@ def taskRunEval(tree,
                 pre_code = "", expr_code = "", name="", copy=True, tempname='_evaluation_object_', 
                 call=None):
     try: 
-        # Prepare code --------------------------------------------------------
-        # If no name given, the object of interest is the output of eval
-        # otherwise, we'll use name to get the object from the environment
-        if not isinstance(tree, ast.Module):
+        # Prepare code and mode -----------------------------------------------
+        if (expr_code and name) or (not expr_code and isinstance(tree, ast.Module)):
+            mode = 'exec'
+        else:
             mode = 'eval'
             tree = ast.Expression(tree)
-        else:
-            mode = 'exec'
 
         # Expression code takes precedence over tree code
         if expr_code: code = expr_code

--- a/tests/test_check_function.py
+++ b/tests/test_check_function.py
@@ -169,7 +169,6 @@ def test_incorrect_usage(sct, sol):
     with pytest.raises(KeyError):
         out = helper.run(data)
 
-@pytest.mark.debug
 @pytest.mark.parametrize('code', [
     'print(round(1.23))',
     'x = print(round(1.23))',

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -62,7 +62,6 @@ def test_compound_statement_for_2(data2):
     output = helper.run(data2)
     assert output['correct']
 
-@pytest.mark.debug
 def test_compount_statement_for_3(data2):
     data2["DC_CODE"] = "my_dict = {'a': 1, 'b': 2}\nfor first, second in my_dict.items():\n    mess = first + ' - ' + str(second)\n    print(mess)"
     output = helper.run(data2)

--- a/tests/test_has_expr.py
+++ b/tests/test_has_expr.py
@@ -1,0 +1,15 @@
+import pytest
+from pythonwhat.local import setup_state
+import helper
+
+def test_has_expr_override_pass():
+    stu = 'x = [1, 2, 3]'
+    sol = 'x = [1, 2, 5]'
+    s = setup_state(stu_code=stu, sol_code=sol)
+    helper.passes(s.check_object('x').has_equal_value(expr_code = 'x[2]', override=3))
+
+def test_has_expr_override_pass_2():
+    stu = 'x = [1, 2, 3]'
+    sol = 'x = [1, 2, 5]'
+    s = setup_state(stu_code=stu, sol_code=sol)
+    helper.passes(s.check_object('x').has_equal_value(override=[1, 2, 3]))

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -225,7 +225,6 @@ Ex().check_object('x', missing_msg='objectnotdefined').has_equal_value('objectin
 
 # Check call ------------------------------------------------------------------
 
-@pytest.mark.debug
 @pytest.mark.parametrize('stu, patt', [
     ('', 'The system wants to check the definition of `test()` but hasn\'t found it.'),
     ('def test(a, b): return 1', 'Check the definition of `test()`. To verify it, we reran `test(1, 2)`. Expected `3`, but got `1`.'),
@@ -364,7 +363,6 @@ Ex().test_correct(
 
 ## test limited stacking ------------------------------------------------------
 
-@pytest.mark.debug
 @pytest.mark.parametrize('sct, patt', [
     ('Ex().check_for_loop().check_body().check_for_loop().check_body().has_equal_output()',
         'Check the first for statement. Did you correctly specify the body? Expected the output `1+1`, but got `1-1`.'),
@@ -380,6 +378,22 @@ for i in range(2):
     output = helper.run({
         'DC_CODE': code % '-',
         'DC_SOLUTION': code % '+',
+        'DC_SCT': sct
+    })
+    assert not output['correct']
+    assert message(output, patt)
+
+## test has_expr --------------------------------------------------------------
+
+@pytest.mark.parametrize('sct, patt', [
+    ("Ex().check_object('x').has_equal_value()", 'Did you correctly define the variable `x`? Expected `[1]`, but got `[0]`.'),
+    ("Ex().has_equal_value(name = 'x')", 'Are you sure you assigned the correct value to `x`?'),
+    ("Ex().has_equal_value(expr_code = 'x[0]')", "Running the expression `x[0]` didn't generate the expected result.")
+])
+def test_has_expr(sct, patt):
+    output = helper.run({
+        'DC_SOLUTION': 'x = [1]',
+        'DC_CODE': 'x = [0]',
         'DC_SCT': sct
     })
     assert not output['correct']

--- a/tests/test_test_object.py
+++ b/tests/test_test_object.py
@@ -1,5 +1,7 @@
 import unittest
 import helper
+from pythonwhat.local import setup_state
+from pythonwhat.Test import TestFail as TF
 import pytest
 
 @pytest.mark.parametrize('sct', [
@@ -49,6 +51,13 @@ def test_check_object_custom_compare(stu_code, passes):
 		'DC_SCT': 'Ex().check_object("x").has_equal_value(func = lambda x,y: len(x) == len(y))'
 	})
     assert output['correct'] == passes
+
+def test_check_object_single_process():
+    state2pids = setup_state('x = 3', '')
+    with pytest.raises(NameError):
+        state2pids.check_object('x')
+    state1pid = setup_state('x = 3', '', pid = 1)
+    helper.passes(state1pid.check_object('x'))
 
 @pytest.mark.parametrize('stu_code, passes', [
     ('arr = 4', False),


### PR DESCRIPTION
@adrian-datacamp To structure our chat later today, it would be great if you could read this PR up front. It contains a extra documentation article explaining what a SingleProcessExercise is, why it exists, and also gives examples on how to write SCTs for it (including new functionality that is also part of this PR). Just read through it and see if you understand and whether it will be sufficient.