### PR TITLE
feat(check_class_def): ability to test class definitions

### DIFF
--- a/docs/articles/checking_compound_statements.rst
+++ b/docs/articles/checking_compound_statements.rst
@@ -254,6 +254,37 @@ The second representation has to be followed when writing the corresponding SCT:
        .check_orelse().check_if_else() \
        .check_orelse().has_equal_output()
 
+Class definition
+~~~~~~~~~~~~~~~~
+
+Suppose you want to check whether a class was defined correctly:
+
+.. code::
+
+
+The following SCT would verify this:
+
+.. code::
+
+    check_class_def('MyInt').multi(
+        check_bases(0).has_equal_ast(),
+        check_body().check_function_def('__init__').multi(
+            check_args('self'),
+            check_args('i'),
+            check_body().set_context(i = 2).multi(
+                check_function('super', signature=False),
+                check_function('super.__init__').check_args(0).has_equal_value()
+            )
+        )
+    )
+
+- ``check_class_def()`` looks for the class definition itself.
+- With ``check_bases()``, you can zoom in on the different basse classes that the class definition inherits from.
+- With ``check_body()``, you zoom in on the class body, after which you can use other functions such
+  as ``check_function_def()`` to look for class methods.
+- Of course, just like for other examples, you can use ``check_correct()`` where necessary,
+  e.g. to verify whether class methods give the right behavior with ``check_call()``
+  before diving into the body of the method itself.
 
 Crazy combo
 ~~~~~~~~~~~

--- a/pythonwhat/check_wrappers.py
+++ b/pythonwhat/check_wrappers.py
@@ -8,34 +8,36 @@ from functools import partial
 import inspect
 
 __PART_WRAPPERS__ = {
-        'iter': 'iterable part',
-        'body': 'body',
-        'key' : 'key part',
-        'value': 'value part',
-        'orelse': 'else part',
-        'finalbody': 'finally part',
-        'test': 'condition' 
-        }
+    'iter': 'iterable part',
+    'body': 'body',
+    'key' : 'key part',
+    'value': 'value part',
+    'orelse': 'else part',
+    'finalbody': 'finally part',
+    'test': 'condition',
+}
 
 __PART_INDEX_WRAPPERS__ = {
-        'ifs': '{ordinal} if',
-        'handlers': '`{index}` `except` block',
-        'context': '{ordinal} context'
-        }
+    'ifs': '{ordinal} if',
+    'bases': '{ordinal} base class',
+    'handlers': '`{index}` `except` block',
+    'context': '{ordinal} context',
+}
 
 __NODE_WRAPPERS__ = {
-        'list_comp': '{ordinal} list comprehension',
-        'generator_exp': '{ordinal} generator expression',
-        'dict_comp': '{ordinal} dictionary comprehension',
-        'for_loop': '{ordinal} for statement',
-        'function_def': 'definition of `{index}()`',
-        'if_exp': '{ordinal} if expression',
-        'if_else': '{ordinal} if statement',
-        'lambda_function': '{ordinal} lambda function',
-        'try_except': '{ordinal} try statement',
-        'while': '{ordinal} `while` loop',
-        'with': '{ordinal} `with` statement'
-        }
+    'list_comp': '{ordinal} list comprehension',
+    'generator_exp': '{ordinal} generator expression',
+    'dict_comp': '{ordinal} dictionary comprehension',
+    'for_loop': '{ordinal} for statement',
+    'function_def': 'definition of `{index}()`',
+    'class_def': 'class definition of `{index}`',
+    'if_exp': '{ordinal} if expression',
+    'if_else': '{ordinal} if statement',
+    'lambda_function': '{ordinal} lambda function',
+    'try_except': '{ordinal} try statement',
+    'while': '{ordinal} `while` loop',
+    'with': '{ordinal} `with` statement',
+}
 
 scts = {}
 

--- a/pythonwhat/parsing.py
+++ b/pythonwhat/parsing.py
@@ -586,6 +586,19 @@ class ForParser(Parser):
             '_target_vars': tv
             })
 
+class ClassDefParser(Parser):
+    """Find class definitions
+    """
+
+    def __init__(self):
+        self.out = {}
+
+    def visit_ClassDef(self, node):
+        self.out[node.name] = {
+            'node': node,
+            'bases': [ {'node': node } for node in node.bases ],
+            'body': node.body,
+        }
 
 class FunctionDefParser(Parser):
     """Find function definitions
@@ -598,7 +611,6 @@ class FunctionDefParser(Parser):
 
     def visit_FunctionDef(self, node):
         self.out[node.name] = self.parse_node(node)
-
 
     @classmethod
     def parse_node(cls, node):
@@ -837,6 +849,7 @@ parser_dict = {
     "if_exps": IfExpParser,
     "whiles": WhileParser,
     "for_loops": ForParser,
+    "class_defs": ClassDefParser,
     "function_defs": FunctionDefParser,
     "lambda_functions": LambdaFunctionParser,
     "list_comps": ListCompParser,

--- a/tests/test_check_class_def.py
+++ b/tests/test_check_class_def.py
@@ -1,0 +1,43 @@
+import pytest
+import helper
+from pythonwhat.local import setup_state
+from pythonwhat.check_syntax import v2_check_functions
+globals().update(v2_check_functions)
+
+
+@pytest.mark.parametrize('stu, passes', [
+    ('', False),
+    ('def A(x): pass', False),
+    ('class A(): pass', False),
+    ('class A(int): pass', False),
+    ('class A(str):\n  def __not_init__(self): pass', False),
+    ('class A(str):\n  def __init__(self): print(1)', False),
+    ('class A(str):\n  def __init__(self): pass', True),
+])
+def test_check_class_def_pass(stu, passes):
+    sol = 'class A(str):\n  def __init__(self): pass'
+    s = setup_state(stu, sol)
+    with helper.verify_sct(passes):
+        s.check_class_def('A').multi(
+            check_bases(0).has_equal_ast(),
+            check_body().check_function_def('__init__').check_body().has_equal_ast()  
+        )
+
+def test_check_wiki_example():
+    code = '''
+class MyInt(int):
+    def __init__(self, i):
+        super().__init__(i + 1)
+'''
+    s = setup_state(code, code)
+    s.check_class_def('MyInt').multi(
+        check_bases(0).has_equal_ast(),
+        check_body().check_function_def('__init__').multi(
+            check_args('self'),
+            check_args('i'),
+            check_body().set_context(i = 2).multi(
+                check_function('super', signature=False),
+                check_function('super.__init__').check_args(0).has_equal_value()
+            )
+        )
+    )


### PR DESCRIPTION
- Similar to how function definitions are checked, but easier,
- Tested (both internals and messages)
- Example added to 'checking compound statements' article

Closes #233 

@dcamposliz this should add the functionality you need for the object oriented programming with Python course. Can you have a look at the examples and the tests in this PR to see if you understand and this is enough to work off of for now? Thanks.