### PR TITLE
Fs/refactor messaging

### DIFF
--- a/docs/articles/checking_compound_statements.rst
+++ b/docs/articles/checking_compound_statements.rst
@@ -113,8 +113,8 @@ However, because we are not merely string-matching the SCT allows for much more 
     rerunning the expressions and comparing the results.
 
 
-``check_for()``
-~~~~~~~~~~~~~~~
+``check_for_loop()``
+~~~~~~~~~~~~~~~~~~~~
 
 The following example checks whether the student properly iterates over a dictionary and does the appropriate printouts:
 

--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -103,14 +103,9 @@ class State(object):
                           'this': d['kwargs'], 
                           **d['kwargs']}
             # don't bother appending if there is no message
-            if not d['msg']: continue
-            if d['msg'].startswith('FMT:'):
-                out = d['msg'].replace('FMT:', "").format(**tmp_kwargs)
-            elif d['msg'].startswith('__JINJA__:'):
-                out = Template(d['msg'].replace('__JINJA__:', "")).render(**tmp_kwargs)
-            else:
-                out = d['msg']
-
+            if not d['msg']:
+                continue
+            out = Template(d['msg'].replace('__JINJA__:', "")).render(**tmp_kwargs)
             out_list.append(out)
 
         # if highlighting info is available, don't put all expand messages

--- a/pythonwhat/check_function.py
+++ b/pythonwhat/check_function.py
@@ -23,9 +23,9 @@ def get_mapped_name(name, mappings):
             if name.startswith(full_name): return name.replace(full_name, orig)
     return name
 
-MISSING_MSG = "__JINJA__:Did you call `{{mapped_name}}()`{{' ' + times if index>0}}?"
-SIG_ISSUE_MSG = "__JINJA__:Have you specified the arguments for `{{mapped_name}}()` using the right syntax?"
-PREPEND_MSG = "__JINJA__:Check your {{ord + ' ' if index>0}}call of `{{mapped_name}}()`. "
+MISSING_MSG = "Did you call `{{mapped_name}}()`{{' ' + times if index>0}}?"
+SIG_ISSUE_MSG = "Have you specified the arguments for `{{mapped_name}}()` using the right syntax?"
+PREPEND_MSG = "Check your {{ord + ' ' if index>0}}call of `{{mapped_name}}()`. "
 def check_function(name, index=0,
                    missing_msg=None,
                    params_not_matched_msg=None,

--- a/pythonwhat/check_has_context.py
+++ b/pythonwhat/check_has_context.py
@@ -5,8 +5,8 @@ from pythonwhat.State import State
 from functools import singledispatch
 from pythonwhat.check_funcs import check_part_index
 
-MSG_INCORRECT_LOOP = "FMT:Have you used the correct iterator variable names? Was expecting `{sol_vars}` but got `{stu_vars}`."
-MSG_INCORRECT_WITH = "FMT:Make sure to use the correct context variable names. Was expecting `{sol_vars}` but got `{stu_vars}`."
+MSG_INCORRECT_LOOP = "Have you used the correct iterator variable names? Was expecting `{{sol_vars}}` but got `{{stu_vars}}`."
+MSG_INCORRECT_WITH = "Make sure to use the correct context variable names. Was expecting `{{sol_vars}}` but got `{{stu_vars}}`."
 
 def has_context(incorrect_msg=None, exact_names=False, state=None):
     # call _has_context, since the built-in singledispatch can only use 1st pos arg
@@ -74,7 +74,7 @@ def has_context_with(state, incorrect_msg, exact_names):
     """
 
     for i in range(len(state.solution_parts['context'])):
-        ctxt_state = check_part_index('context', i, '{ordinal} context', state=state)
+        ctxt_state = check_part_index('context', i, '{{ordinal}} context', state=state)
         _has_context(ctxt_state, incorrect_msg or MSG_INCORRECT_WITH, exact_names)
 
     return state

--- a/pythonwhat/check_object.py
+++ b/pythonwhat/check_object.py
@@ -47,10 +47,10 @@ def check_object(index, missing_msg=None, expand_msg=None, state=None, typestr="
         state.assert_root('check_object')
 
     if missing_msg is None:
-        missing_msg = "__JINJA__:Did you define the {{typestr}} `{{index}}` without errors?"
+        missing_msg = "Did you define the {{typestr}} `{{index}}` without errors?"
 
     if expand_msg is None:
-        expand_msg = "__JINJA__:Did you correctly define the {{typestr}} `{{index}}`? "
+        expand_msg = "Did you correctly define the {{typestr}} `{{index}}`? "
 
     rep = Reporter.active_reporter
 
@@ -106,7 +106,7 @@ def is_instance(inst, not_instance_msg=None, state=None):
     sol_name = state.solution_parts.get('name')
     stu_name = state.student_parts.get('name')
 
-    if not_instance_msg is None: not_instance_msg = "__JINJA__:Is it a {{inst.__name__}}?"
+    if not_instance_msg is None: not_instance_msg = "Is it a {{inst.__name__}}?"
 
     if not isInstanceInProcess(sol_name, inst, state.solution_process):
         raise InstructorError("`is_instance()` noticed that `%s` is not a `%s` in the solution process." % (sol_name, inst.__name__))
@@ -154,9 +154,9 @@ def check_keys(key, missing_msg=None, expand_msg=None, state=None):
     state.assert_is(['object_assignments'], 'is_instance', ['check_object', 'check_df'])
 
     if missing_msg is None:
-        missing_msg = "__JINJA__:There is no {{ 'column' if 'DataFrame' in parent.typestr else 'key' }} `'{{key}}'`."
+        missing_msg = "There is no {{ 'column' if 'DataFrame' in parent.typestr else 'key' }} `'{{key}}'`."
     if expand_msg is None:
-        expand_msg = "__JINJA__:Did you correctly set the {{ 'column' if 'DataFrame' in parent.typestr else 'key' }} `'{{key}}'`? "
+        expand_msg = "Did you correctly set the {{ 'column' if 'DataFrame' in parent.typestr else 'key' }} `'{{key}}'`? "
 
     rep = Reporter.active_reporter
 
@@ -175,7 +175,7 @@ def check_keys(key, missing_msg=None, expand_msg=None, state=None):
         if isinstance(key, str):
             slice_val = ast.Str(s=key)
         else:
-            slice_val = ast.parse('{}'.format(key)).body[0].value
+            slice_val = ast.parse(str(key)).body[0].value
         expr = ast.Subscript(value=ast.Name(id=name, ctx=ast.Load()),
                              slice=ast.Index(value=slice_val),
                              ctx=ast.Load())

--- a/pythonwhat/check_wrappers.py
+++ b/pythonwhat/check_wrappers.py
@@ -18,33 +18,33 @@ __PART_WRAPPERS__ = {
 }
 
 __PART_INDEX_WRAPPERS__ = {
-    'ifs': '{ordinal} if',
-    'bases': '{ordinal} base class',
-    'handlers': '`{index}` `except` block',
-    'context': '{ordinal} context',
+    'ifs': '{{ordinal}} if',
+    'bases': '{{ordinal}} base class',
+    'handlers': '`{{index}}` `except` block',
+    'context': '{{ordinal}} context',
 }
 
 __NODE_WRAPPERS__ = {
-    'list_comp': '{ordinal} list comprehension',
-    'generator_exp': '{ordinal} generator expression',
-    'dict_comp': '{ordinal} dictionary comprehension',
-    'for_loop': '{ordinal} for statement',
-    'function_def': 'definition of `{index}()`',
-    'class_def': 'class definition of `{index}`',
-    'if_exp': '{ordinal} if expression',
-    'if_else': '{ordinal} if statement',
-    'lambda_function': '{ordinal} lambda function',
-    'try_except': '{ordinal} try statement',
-    'while': '{ordinal} `while` loop',
-    'with': '{ordinal} `with` statement',
+    'list_comp': '{{ordinal}} list comprehension',
+    'generator_exp': '{{ordinal}} generator expression',
+    'dict_comp': '{{ordinal}} dictionary comprehension',
+    'for_loop': '{{ordinal}} for loop',
+    'function_def': 'definition of `{{index}}()`',
+    'class_def': 'class definition of `{{index}}`',
+    'if_exp': '{{ordinal}} if expression',
+    'if_else': '{{ordinal}} if statement',
+    'lambda_function': '{{ordinal}} lambda function',
+    'try_except': '{{ordinal}} try statement',
+    'while': '{{ordinal}} `while` loop',
+    'with': '{{ordinal}} `with` statement',
 }
 
 scts = {}
 
 # make has_equal_part wrappers
 
-scts['has_equal_name'] = partial(has_equal_part, 'name', msg='Make sure to use the correct {name}, was expecting {sol_part[name]}, instead got {stu_part[name]}.')
-scts['is_default'] = partial(has_equal_part, 'is_default', msg="__JINJA__:Make sure it {{ 'has' if sol_part.is_default else 'does not have'}} a default argument.")
+scts['has_equal_name'] = partial(has_equal_part, 'name', msg='Make sure to use the correct {{name}}, was expecting {{sol_part[name]}}, instead got {{stu_part[name]}}.')
+scts['is_default'] = partial(has_equal_part, 'is_default', msg="Make sure it {{ 'has' if sol_part.is_default else 'does not have'}} a default argument.")
 
 # include rest of wrappers
 for k, v in __PART_WRAPPERS__.items():

--- a/pythonwhat/has_funcs.py
+++ b/pythonwhat/has_funcs.py
@@ -151,7 +151,7 @@ def has_equal_ast(incorrect_msg=None,
     if append is None: # if not specified, set to False if incorrect_msg was manually specified
         append = incorrect_msg is None
     if incorrect_msg is None:
-        incorrect_msg = "__JINJA__:Expected `{{sol_str}}`, but got `{{stu_str}}`."
+        incorrect_msg = "Expected `{{sol_str}}`, but got `{{stu_str}}`."
 
     def parse_tree(tree):
         # get contents of module.body if only 1 element
@@ -177,12 +177,12 @@ def has_equal_ast(incorrect_msg=None,
 
     return state
 
-DEFAULT_INCORRECT_MSG="__JINJA__:Expected {{test_desc}}`{{sol_eval}}`, but got `{{stu_eval}}`."
-DEFAULT_ERROR_MSG="__JINJA__:Running {{'it' if parent['part'] else 'the higlighted expression'}} generated an error: `{{stu_str}}`."
-DEFAULT_ERROR_MSG_INV="__JINJA__:Running {{'it' if parent['part'] else 'the higlighted expression'}} didn't generate an error, but it should!"
-DEFAULT_UNDEFINED_NAME_MSG="__JINJA__:Running {{'it' if parent['part'] else 'the higlighted expression'}} should define a variable `{{name}}` without errors, but it doesn't."
-DEFAULT_INCORRECT_NAME_MSG="__JINJA__:Are you sure you assigned the correct value to `{{name}}`?"
-DEFAULT_INCORRECT_EXPR_CODE_MSG="__JINJA__:Running the expression `{{expr_code}}` didn't generate the expected result."
+DEFAULT_INCORRECT_MSG="Expected {{test_desc}}`{{sol_eval}}`, but got `{{stu_eval}}`."
+DEFAULT_ERROR_MSG="Running {{'it' if parent['part'] else 'the higlighted expression'}} generated an error: `{{stu_str}}`."
+DEFAULT_ERROR_MSG_INV="Running {{'it' if parent['part'] else 'the higlighted expression'}} didn't generate an error, but it should!"
+DEFAULT_UNDEFINED_NAME_MSG="Running {{'it' if parent['part'] else 'the higlighted expression'}} should define a variable `{{name}}` without errors, but it doesn't."
+DEFAULT_INCORRECT_NAME_MSG="Are you sure you assigned the correct value to `{{name}}`?"
+DEFAULT_INCORRECT_EXPR_CODE_MSG="Running the expression `{{expr_code}}` didn't generate the expected result."
 def has_expr(incorrect_msg=None,
              error_msg=None,
              undefined_msg=None,
@@ -237,7 +237,7 @@ def has_expr(incorrect_msg=None,
 
         if (test == 'error') ^ isinstance(eval_sol, Exception):
             raise InstructorError("Evaluating expression raised error in solution process (or not an error if testing for one). "
-                            "Error: {} - {}".format(type(eval_sol), str_sol))
+                                  "Error: {} - {}".format(type(eval_sol), str_sol))
         if isinstance(eval_sol, ReprFail):
             raise InstructorError("Couldn't extract the value for the highlighted expression from the solution process: " + eval_sol.info)
 
@@ -410,8 +410,8 @@ from pythonwhat.Test import Test, DefinedCollTest, EqualTest
 
 def has_import(name,
                same_as=False,
-               not_imported_msg="__JINJA__:Did you import `{{pkg}}`?",
-               incorrect_as_msg="__JINJA__:Did you import `{{pkg}}` as `{{alias}}`?",
+               not_imported_msg="Did you import `{{pkg}}`?",
+               incorrect_as_msg="Did you import `{{pkg}}` as `{{alias}}`?",
                state=None):
     """Checks whether student imported a package or function correctly.
 
@@ -549,7 +549,7 @@ def has_printout(index,
     state.assert_root('has_printout')
 
     if not_printed_msg is None:
-        not_printed_msg = "__JINJA__:Have you used `{{sol_call}}` to do the appropriate printouts?"
+        not_printed_msg = "Have you used `{{sol_call}}` to do the appropriate printouts?"
 
     try:
         sol_call_ast = state.solution_function_calls['print'][index]['node']

--- a/pythonwhat/probe.py
+++ b/pythonwhat/probe.py
@@ -13,7 +13,6 @@ TEST_NAMES = [
     "test_object",
     "test_correct",
     "test_if_else",
-    "test_if_exp",
     "test_for_loop",
     "test_function",
     "test_list_comp",
@@ -31,7 +30,6 @@ TEST_NAMES = [
 
 SUB_TESTS = {
     "test_if_else": ['test', 'body', 'orelse'],
-    "test_if_exp": ['test', 'body', 'orelse'],
     "test_list_comp": ['comp_iter', 'body', 'ifs'],
     "check_correct": ['check', 'diagnose'],
     "test_for_loop": ['for_iter', 'body', 'orelse'],

--- a/pythonwhat/test_funcs/__init__.py
+++ b/pythonwhat/test_funcs/__init__.py
@@ -1,6 +1,6 @@
 
 from .test_compound_statement import test_with, test_list_comp, \
-    test_if_else, test_if_exp, test_for_loop, test_while_loop, \
+    test_if_else, test_for_loop, test_while_loop, \
     test_expression_output, test_expression_result, \
     test_object_after_expression, test_function_definition
 

--- a/pythonwhat/test_funcs/test_compound_statement.py
+++ b/pythonwhat/test_funcs/test_compound_statement.py
@@ -13,8 +13,6 @@ def test_if_else(index=1,
                  test=None,
                  body=None,
                  orelse=None,
-                 expand_message=True,
-                 use_if_exp=False,
                  state=None):
     """Test parts of the if statement.
 
@@ -44,8 +42,6 @@ def test_if_else(index=1,
         It should be passed as a lambda expression or a function definition. The functions that are ran should
         be other pythonwhat test functions, and they will be tested specifically on only the else part of
         the if statement.
-      expand_message (bool): if true, feedback messages will be expanded with :code:`in the ___ of the if statement on
-        line ___`. Defaults to True. If False, :code:`test_if_else()` will generate no extra feedback.
 
     :Example:
 
@@ -71,32 +67,15 @@ def test_if_else(index=1,
         This SCT will pass as :code:`test_expression_output()` is ran on the body of the if statement and it will output
         the same thing in the solution as in the student code.
     """
-
-    MSG_MISSING = "FMT:The system wants to check the {typestr}, but it hasn't found it. Have another look at your code."
-    MSG_PREPEND = "FMT:Check the {typestr}. "
-
-    # get state with specific if block
-    node_name = 'if_exps' if use_if_exp else 'if_elses'
-    # TODO original typestr for check_node used if rather than `if`
-    state = check_node(node_name, index-1, "{ordinal} if statement", MSG_MISSING, MSG_PREPEND if expand_message else "", state=state)
-
-    # run sub tests
-    multi(test, state = check_part('test', 'condition', expand_msg=None if expand_message else "", state=state))
-    multi(body, state = check_part('body', 'body', expand_msg=None if expand_message else "", state=state))
-    multi(orelse, state = check_part('orelse', 'else part', expand_msg=None if expand_message else "", state=state))
-
-
-test_if_exp = partial(test_if_else, use_if_exp = True)
-# update test_if_exp function signature (docstring, etc..)
-update_wrapper(test_if_exp, test_if_else)
-test_if_exp.__name__ = 'test_if_exp'
-
+    state = check_node('if_elses', index-1, typestr='{{ordinal}} if expression', state=state)
+    multi(test, state = check_part('test', 'condition', state=state))
+    multi(body, state = check_part('body', 'body', state=state))
+    multi(orelse, state = check_part('orelse', 'else part', state=state))
 
 def test_for_loop(index=1,
                   for_iter=None,
                   body=None,
                   orelse=None,
-                  expand_message=True,
                   state=None):
     """Test parts of the for loop.
 
@@ -124,8 +103,6 @@ def test_for_loop(index=1,
         It should be passed as a lambda expression or a function. The functions that are ran should
         be other pythonwhat test functions, and they will be tested specifically on only the else part of
         the for loop.
-      expand_message (bool): if true, feedback messages will be expanded with :code:`in the ___ of the for loop on
-        line ___`. Defaults to True. If False, :code:`test_for_loop()` will generate no extra feedback.
 
     :Example:
         Student code::
@@ -147,22 +124,16 @@ def test_for_loop(index=1,
         This SCT will evaluate to True as the function :code:`range` is used in the sequence and the function
         :code:`test_exression_output()` will pass on the body code.
     """
-    MSG_MISSING = "FMT:Define more for loops."
-    MSG_PREPEND = "FMT:Check the {typestr}. "
+    state = check_node('for_loops', index-1, "{{ordinal}} for loop", state=state)
 
-
-    state = check_node('for_loops', index-1, "{ordinal} for loop", MSG_MISSING, MSG_PREPEND, state=state)
-
-    # TODO for_iter is a level up, so shouldn't have targets set, but this is done is check_node
-    multi(for_iter, state = check_part('iter', 'sequence part', expand_msg=None if expand_message else "", state=state))
-    multi(body,     state = check_part('body', 'body', expand_msg=None if expand_message else "", state=state))
-    multi(orelse,   state = check_part('orelse', 'else part', expand_msg=None if expand_message else "", state=state))
+    multi(for_iter, state = check_part('iter', 'sequence part', state=state))
+    multi(body,     state = check_part('body', 'body', state=state))
+    multi(orelse,   state = check_part('orelse', 'else part', state=state))
 
 def test_while_loop(index=1,
                     test=None,
                     body=None,
                     orelse=None,
-                    expand_message=True,
                     state=None):
     """Test parts of the while loop.
 
@@ -192,8 +163,6 @@ def test_while_loop(index=1,
           It should be passed as a lambda expression or a function definition. The functions that are ran should
           be other pythonwhat test functions, and they will be tested specifically on only the else part of
           the while loop.
-        expand_message (bool): if true, feedback messages will be expanded with :code:`in the ___ of the while loop on
-          line ___`. Defaults to True. If False, `test_for_loop()` will generate no extra feedback.
 
     :Example:
 
@@ -220,16 +189,10 @@ def test_while_loop(index=1,
       This SCT will evaluate to True as condition test will have thes same result in student
       and solution code and `test_exression_output()` will pass on the body code.
     """
-
-    MSG_MISSING = "FMT:Define more while loops."
-    MSG_PREPEND = "FMT:Check the {typestr}. "
-
-    state = check_node('whiles', index-1, "{ordinal} while loop", MSG_MISSING, MSG_PREPEND if expand_message else "", state=state)
-
-    expand_msg = None if expand_message else ""
-    multi(test, state = check_part('test', 'condition', expand_msg=expand_msg, state=state))
-    multi(body, state = check_part('body', 'body', expand_msg=expand_msg, state=state))
-    multi(orelse, state = check_part('orelse', 'else part', expand_msg=expand_msg, state=state))
+    state = check_node('whiles', index-1, "{{ordinal}} while loop", state=state)
+    multi(test, state = check_part('test', 'condition', state=state))
+    multi(body, state = check_part('body', 'body', state=state))
+    multi(orelse, state = check_part('orelse', 'else part', state=state))
 
 
 def test_function_definition(name,
@@ -248,7 +211,6 @@ def test_function_definition(name,
                              wrong_output_msg=None,
                              no_error_msg=None,
                              wrong_error_msg=None,
-                             expand_message=True,
                              state=None):
     """Test a function definition.
 
@@ -289,9 +251,6 @@ def test_function_definition(name,
         wrong_output_msg (str): message if one of the tested functions calls' output did not match.
         no_error_msg (str): message if one of the tested function calls' result did not generate an error.
         wrong_error_msg (str): message if the error that one of the tested function calls generated did not match.
-        expand_message (bool): only relevant if there is a body test. If True, feedback messages defined in the
-            body test will be preceded by 'In your definition of ___, '. If False, `test_function_definition()`
-            will generate no extra feedback if the body test fails. Defaults to True.
 
     :Example:
 
@@ -322,28 +281,17 @@ def test_function_definition(name,
             test_function_definition('shout', args_defaults = False    # pass
                     body = test_function('print', args = []]))
     """
-    MSG_MISSING = "FMT:You didn't define the following function: {typestr}."
-    MSG_PREPEND = "FMT:Check your definition of {typestr}. "    
 
     # what the function will be referred to as
-    typestr = "`{}()`".format(name)
-    get_func_child = partial(check_node, 'function_defs', name, typestr, not_called_msg or MSG_MISSING, state=state)
-    child =  get_func_child(expand_msg = MSG_PREPEND if expand_message else "")
-
-    # make a temporary child state, to reflect that there were two types of 
-    # messages prepended in the original function
-    quiet_child = get_func_child(expand_msg = "")
-    prep_child2 = get_func_child(expand_msg = MSG_PREPEND)
+    child = check_node('function_defs', name, 'definition of `{{index}}()`', state=state)
 
     test_args(arg_names, arg_defaults, 
               nb_args_msg, arg_names_msg, arg_defaults_msg,
-              prep_child2, quiet_child)
+              child)
 
-    multi(body, state=check_part('body', "", expand_msg=None if expand_message else "", state=child))
+    multi(body, state=check_part('body', "", state=child))
 
     # Test function calls -----------------------------------------------------
-
-    #fun_name = ("`%s()`" % name)
 
     for el in (results or []):
         el = fix_format(el)
@@ -351,7 +299,7 @@ def test_function_definition(name,
                 incorrect_msg = wrong_result_msg,
                 error_msg = wrong_result_msg,
                 argstr = '`{}{}`'.format(name, stringify(el)),
-                state = quiet_child)
+                state=child)
 
     for el in (outputs or []):
         el = fix_format(el)
@@ -359,7 +307,7 @@ def test_function_definition(name,
                 incorrect_msg = wrong_output_msg,
                 error_msg = wrong_output_msg,
                 argstr = '`{}{}`'.format(name, stringify(el)),
-                state = quiet_child)
+                state=child)
 
     for el in (errors or []):
         el = fix_format(el)
@@ -367,31 +315,31 @@ def test_function_definition(name,
                 incorrect_msg = wrong_error_msg,
                 error_msg = no_error_msg,
                 argstr = '`{}{}`'.format(name, stringify(el)),
-                state = quiet_child)
+                state=child)
 
 
 def test_args(arg_names, arg_defaults, 
               nb_args_msg, arg_names_msg, arg_defaults_msg, 
-              child, quiet_child):
+              child):
 
-    MSG_NUM_ARGS = "FMT:You should define {parent[typestr]} with {sol_len} arguments, instead got {stu_len}."
-    MSG_BAD_ARG_NAME = "FMT:The {parent[ordinal]} {parent[part]} should be called `{sol_part[name]}`, instead got `{stu_part[name]}`."
-    MSG_BAD_DEFAULT = "FMT:The {parent[part]} `{stu_part[name]}` should have no default."
-    MSG_INC_DEFAULT = "FMT:The {parent[part]} `{stu_part[name]}` does not have the correct default."
+    MSG_NUM_ARGS = "You should define {{parent[typestr]}} with {{sol_len}} arguments, instead got {{stu_len}}."
+    MSG_BAD_ARG_NAME = "The {{parent[ordinal]}} {{parent[part]}} should be called `{{sol_part[name]}}`, instead got `{{stu_part[name]}}`."
+    MSG_BAD_DEFAULT = "The {{parent[part]}} `{{stu_part[name]}}` should have no default."
+    MSG_INC_DEFAULT = "The {{parent[part]}} `{{stu_part[name]}}` does not have the correct default."
 
-    MSG_NO_VARARG = "FMT:Have you specified an argument to take a `*` argument and named it `{sol_part[*args][name]}`?"
-    MSG_NO_KWARGS = "FMT:Have you specified an argument to take a `**` argument and named it `{sol_part[**kwargs][name]}`?"
-    MSG_VARARG_NAME = "FMT:Have you specified an argument to take a `*` argument and named it `{sol_part[name]}`?"
-    MSG_KWARG_NAME = "FMT:Have you specified an argument to take a `**` argument and named it `{sol_part[name]}`?"
+    MSG_NO_VARARG = "Have you specified an argument to take a `*` argument and named it `{{sol_part['*args'][name]}}`?"
+    MSG_NO_KWARGS = "Have you specified an argument to take a `**` argument and named it `{{sol_part['**kwargs'][name]}}`?"
+    MSG_VARARG_NAME = "Have you specified an argument to take a `*` argument and named it `{{sol_part[name]}}`?"
+    MSG_KWARG_NAME = "Have you specified an argument to take a `**` argument and named it `{{sol_part[name]}}`?"
 
     if arg_names or arg_defaults:
         # test number of args
-        has_equal_part_len('_spec1_args', nb_args_msg or MSG_NUM_ARGS, state=quiet_child)
+        has_equal_part_len('_spec1_args', nb_args_msg or MSG_NUM_ARGS, state=child)
 
         # iterate over each arg, testing name and default
         for ii in range(len(child.solution_parts['_spec1_args'])):
             # get argument state
-            arg_state = check_part_index('_spec1_args', ii, 'argument', "NO MISSING MSG", expand_msg="", state=child)
+            arg_state = check_part_index('_spec1_args', ii, 'argument', "NO MISSING MSG", state=child)
             # test exact name
             has_equal_part('name', arg_names_msg or MSG_BAD_ARG_NAME, arg_state)
 
@@ -400,15 +348,15 @@ def test_args(arg_names, arg_defaults,
                 has_equal_part('is_default', arg_defaults_msg or MSG_BAD_DEFAULT, arg_state)
                 # test default value, use if to prevent running a process no default
                 if arg_state.solution_parts['is_default']:
-                    has_equal_value(incorrect_msg = arg_defaults_msg or MSG_INC_DEFAULT, error_msg="error message", append=True, state=arg_state)
+                    has_equal_value(incorrect_msg = arg_defaults_msg or MSG_INC_DEFAULT, append=True, state=arg_state)
 
         # test *args and **kwargs
         if child.solution_parts['*args']:
-            vararg = check_part('*args', "", missing_msg=MSG_NO_VARARG, expand_msg="", state=child)
+            vararg = check_part('*args', "", missing_msg=MSG_NO_VARARG, state=child)
             has_equal_part('name', MSG_VARARG_NAME, state=vararg)
         
         if child.solution_parts['**kwargs']:
-            kwarg = check_part('**kwargs', "", missing_msg=MSG_NO_KWARGS, expand_msg="", state=child)
+            kwarg = check_part('**kwargs', "", missing_msg=MSG_NO_KWARGS, state=child)
             has_equal_part('name', MSG_KWARG_NAME, state=kwarg)
 
 
@@ -474,7 +422,6 @@ def test_with(index,
               undefined_msg=None,
               context_vals_len_msg=None,
               context_vals_msg=None,
-              expand_message=True,
               state=None):
     """Test a with statement.
 with open_file('...') as bla:
@@ -487,16 +434,14 @@ with open_file('...') as file:
 
     """
 
-    MSG_MISSING = "Define more `with` statements."
-    MSG_PREPEND = "FMT:Check the {typestr}. "
     MSG_NUM_CTXT = "Make sure to use the correct number of context variables. It seems you defined too many."
     MSG_NUM_CTXT2 = "Make sure to use the correct number of context variables. It seems you defined too little."
-    MSG_CTXT_NAMES = "FMT:Make sure to use the correct context variable names. Was expecting `{sol_vars}` but got `{stu_vars}`."
+    MSG_CTXT_NAMES = "Make sure to use the correct context variable names. Was expecting `{{sol_vars}}` but got `{{stu_vars}}`."
 
-    check_with = partial(check_node, 'withs', index-1, "{ordinal} `with` statement", MSG_MISSING, state=state)
+    check_with = partial(check_node, 'withs', index-1, "{{ordinal}} `with` statement", state=state)
 
-    child =  check_with(MSG_PREPEND if expand_message else "")
-    child2 = check_with(MSG_PREPEND if expand_message else "")
+    child =  check_with()
+    child2 = check_with()
 
     if context_vals:
         # test context var names ----
@@ -509,10 +454,9 @@ with open_file('...') as file:
     # Context sub tests ----
     if context_tests and not isinstance(context_tests, list): context_tests = [context_tests]
 
-    expand_msg = None if expand_message else ""
     for i, context_test in enumerate(context_tests or []):
         # partial the substate check, because the function uses two prepended messages
-        check_context = partial(check_part_index, 'context', i, "%s context"%utils.get_ord(i+1), missing_msg=MSG_NUM_CTXT2, expand_msg=expand_msg)
+        check_context = partial(check_part_index, 'context', i, "%s context"%utils.get_ord(i+1), missing_msg=MSG_NUM_CTXT2)
 
         check_context(state=child)                   # test exist
 
@@ -521,7 +465,7 @@ with open_file('...') as file:
     
     # Body sub tests ----
     if body is not None:
-        body_state = check_part('body', 'body', expand_msg=expand_msg, state=child2)
+        body_state = check_part('body', 'body', state=child2)
 
         with_context(body, state=body_state)
 
@@ -533,53 +477,43 @@ def test_list_comp(index=1,
                    body=None,
                    ifs=None,
                    insufficient_ifs_msg=None,
-                   expand_message=True,
                    state=None):
     """Test list comprehension."""
-    test_comp("{ordinal} list comprehension", 'list_comps', **(locals()))
+    test_comp("{{ordinal}} list comprehension", 'list_comps', **(locals()))
 
 
 def test_comp(typestr, comptype, index, iter_vars_names,
               not_called_msg, insufficient_ifs_msg, incorrect_iter_vars_msg,
               comp_iter, ifs, key=None, body=None, value=None,
-              expand_message = True,
               rep=None, state=None):
 
-    MSG_NOT_CALLED = "FMT:The system wants to check the {typestr} but hasn't found it."
-    MSG_PREPEND = "FMT:Check the {typestr}. "
+    MSG_INCORRECT_ITER_VARS = "Have you used the correct iterator variables?"
+    MSG_INCORRECT_NUM_ITER_VARS = "Have you used {{num_vars}} iterator variables?"
+    MSG_INSUFFICIENT_IFS = "Have you used {{sol_len}} ifs?"
 
-    MSG_INCORRECT_ITER_VARS = "FMT:Have you used the correct iterator variables in the {parent[typestr]}? Be sure to use the correct names."
-    MSG_INCORRECT_NUM_ITER_VARS = "FMT:Have you used {num_vars} iterator variables in the {parent[typestr]}?"
-    MSG_INSUFFICIENT_IFS = "FMT:Have you used {sol_len} ifs inside the {parent[typestr]}?"
-
-    # if true, set expand_message to default (for backwards compatibility)
-    expand_message = MSG_PREPEND if expand_message is True else (expand_message or "")
     # make sure other messages are set to default if None
-    if insufficient_ifs_msg is None: insufficient_ifs_msg = MSG_INSUFFICIENT_IFS
-    if not_called_msg is None: not_called_msg = MSG_NOT_CALLED
-
-    # TODO MSG: function was not consistent with prepending, so use state w/o expand_message
-    quiet_state = check_node(comptype, index-1, typestr, not_called_msg, expand_msg="", state=state)
+    if insufficient_ifs_msg is None:
+        insufficient_ifs_msg = MSG_INSUFFICIENT_IFS
 
     # get comprehension
-    state = check_node(comptype, index-1, typestr, not_called_msg, expand_msg=None if expand_message else "", state=state)
+    child = check_node(comptype, index-1, typestr, missing_msg=not_called_msg, state=state)
 
     # test comprehension iter and its variable names (or number of variables)
-    if comp_iter: multi(comp_iter, state=check_part("iter", "iterable part", state=state))
+    if comp_iter: multi(comp_iter, state=check_part("iter", "iterable part", state=child))
 
     # test iterator variables
     default_msg = MSG_INCORRECT_ITER_VARS if iter_vars_names else MSG_INCORRECT_NUM_ITER_VARS
-    has_context(incorrect_iter_vars_msg or default_msg, iter_vars_names, state=quiet_state)
+    has_context(incorrect_iter_vars_msg or default_msg, iter_vars_names, state=child)
 
     # test the main expressions.
-    if body:   multi(body,  state=check_part("body", "body", expand_msg=None if expand_message else "", state=state))        # list and gen comp
-    if key:    multi(key,   state=check_part("key", "key part", expand_msg=None if expand_message else "",  state=state))    # dict comp
-    if value:  multi(value, state=check_part("value", "value part", expand_msg=None if expand_message else "", state=state)) # ""
+    if body:   multi(body,  state=check_part("body", "body", state=child))        # list and gen comp
+    if key:    multi(key,   state=check_part("key", "key part",  state=child))    # dict comp
+    if value:  multi(value, state=check_part("value", "value part", state=child)) # ""
 
     # test a list of ifs. each entry corresponds to a filter in the comprehension.
     for i, if_test in enumerate(ifs or []):
         # test that ifs are same length
-        has_equal_part_len('ifs', insufficient_ifs_msg, state=quiet_state)
+        has_equal_part_len('ifs', insufficient_ifs_msg, state=child)
         # test individual ifs
-        multi(if_test, state=check_part_index("ifs", i, utils.get_ord(i+1) + " if", state=state))
+        multi(if_test, state=check_part_index("ifs", i, utils.get_ord(i+1) + " if", state=child))
 

--- a/pythonwhat/utils_ast.py
+++ b/pythonwhat/utils_ast.py
@@ -15,7 +15,7 @@ def wrap_in_module(node):
     return new_node
 
 def assert_ast(state, element, fmt_kwargs):
-    patt = "__JINJA__:You are zooming in on the {{part}}, but it is not an AST, so it can't be re-run."
+    patt = "You are zooming in on the {{part}}, but it is not an AST, so it can't be re-run."
     _err_msg = "SCT fails on solution: "
     _err_msg += state.build_message(patt, fmt_kwargs)
     # element can also be { 'node': AST }

--- a/tests/test_check_function.py
+++ b/tests/test_check_function.py
@@ -190,6 +190,19 @@ def test_function_parser(code):
     p.visit(ast.parse(code))
     assert 'round' in p.out
 
+def test_check_function_parser_mappings_1():
+    code = "import numpy as np\nnp.random.randint(1, 7)"
+    s = setup_state(code, code)
+    s.check_function('numpy.random.randint')
+
+# Because the mappings are only found for the substate that is zoomed in on,
+# The `import numpy as np` part is not found, because it's outside of the for loop.
+# This should be fixed!!!
+@pytest.mark.xfail
+def test_check_function_parser_mappings_2():
+    code = "import numpy as np\nfor x in range(0): np.random.randint(1, 7)"
+    s = setup_state(code, code)
+    s.check_for_loop().check_body().check_function('numpy.random.randint')
 
 # Incorrect usage -------------------------------------------------------------
 

--- a/tests/test_check_if_else.py
+++ b/tests/test_check_if_else.py
@@ -73,14 +73,12 @@ def orelse_test():
     test_if_else(index = 1,
                   test = test_test2,
                   body = body_test2,
-                  orelse = orelse_test2,
-                  expand_message = False)
+                  orelse = orelse_test2)
 
 test_if_else(index=1,
              test=test_test,
              body=body_test,
-             orelse=orelse_test,
-             expand_message = False)
+             orelse=orelse_test)
     ''',
     '''
 test_if_else(index=1,

--- a/tests/test_check_list_comp.py
+++ b/tests/test_check_list_comp.py
@@ -30,9 +30,9 @@ def test_check_list_comp_basic(stu, passes):
 @pytest.mark.parametrize('stu, passes, patt, lines', [
     ("", False, "The system wants to check the first list comprehension but hasn't found it.", []),
     ("[key for key in x.keys()]", False, "Check the first list comprehension. Did you correctly specify the iterable part?", [1, 1, 17, 24]),
-    ("[a + str(b) for a,b in x.items()]", False, "Have you used the correct iterator variables in the first list comprehension? Be sure to use the correct names.", [1, 1, 17, 19]),
+    ("[a + str(b) for a,b in x.items()]", False, 'Check the first list comprehension. Have you used the correct iterator variables?', [1, 1, 17, 19]),
     ("[key + '_' + str(val) for key,val in x.items()]", False, "Did you correctly specify the body?", [1, 1, 2, 21]),
-    ("[key + str(val) for key,val in x.items()]", False, "Have you used 2 ifs inside the first list comprehension?", []),
+    ("[key + str(val) for key,val in x.items()]", False, "Check the first list comprehension. Have you used 2 ifs?", []),
     ("[key + str(val) for key,val in x.items() if hasattr(key, 'test') if hasattr(key, 'test')]", False, "Did you correctly specify the first if? Did you call <code>isinstance()</code>?", [1, 1, 45, 64]),
     ("[key + str(val) for key,val in x.items() if isinstance(key, str) if hasattr(key, 'test')]", False, "Did you correctly specify the second if? Did you call <code>isinstance()</code>?", [1, 1, 69, 88]),
     ("[key + str(val) for key,val in x.items() if isinstance(key, str) if isinstance(key, str)]", False, "Did you correctly specify the argument <code>obj</code>? Expected <code>val</code>, but got <code>key</code>.", [1, 1, 80, 82]),
@@ -50,8 +50,7 @@ test_list_comp(index=1,
                body=lambda: test_expression_result(context_vals = ['a', 2]),
                ifs=[lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False]),
                     lambda: test_function_v2('isinstance', params = ['obj'], do_eval = [False])],
-               insufficient_ifs_msg=None,
-               expand_message=True)
+               insufficient_ifs_msg=None)
     '''
     res = helper.run({ "DC_PEC": pec, "DC_CODE": stu, "DC_SOLUTION": sol, "DC_SCT": sct })
     assert res['correct'] == passes

--- a/tests/test_check_object.py
+++ b/tests/test_check_object.py
@@ -305,3 +305,23 @@ def test_several_assignments_2(diff_assign_data):
     })
     assert not res['correct']
     helper.no_line_info(res)
+
+# Object Assignment parser -------------------------------------------------------------
+
+from pythonwhat.parsing import ObjectAssignmentParser
+import ast
+
+@pytest.mark.parametrize('code', [
+    'x = 2',
+    'x = a[1]',
+    'x = a.b[1]',
+    'x = sales.loc[(["ca", "tx"], 2), :]',
+    'x = fun(a)',
+    'x = a + b',
+    'x = (a + b) + c',
+    'x = [ a for b in c ]',
+])
+def test_object_assignment_parser(code):
+    p = ObjectAssignmentParser()
+    p.visit(ast.parse(code))
+    assert 'x' in p.out

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -337,10 +337,10 @@ def test_has_import_custom(stu, patt):
 
 @pytest.mark.parametrize('stu, patt, cols, cole', [
     ("my_dict = {'a': 1, 'b': 2}\nfor key, value in my_dict.items(): x = key + ' -- ' + str(value)",
-     "Check the first for statement. Did you correctly specify the body? Are you sure you assigned the correct value to `x`?",
+     "Check the first for loop. Did you correctly specify the body? Are you sure you assigned the correct value to `x`?",
      36, 64),
     ("my_dict = {'a': 1, 'b': 2}\nfor key, value in my_dict.items(): x = key + ' - ' + str(value)",
-     "Check the first for statement. Did you correctly specify the body? Expected the output `a - 1`, but got `no printouts`.",
+     "Check the first for loop. Did you correctly specify the body? Expected the output `a - 1`, but got `no printouts`.",
      36, 63)
 ])
 def test_has_equal_x(stu, patt, cols, cole):
@@ -403,9 +403,9 @@ Ex().test_correct(
 
 @pytest.mark.parametrize('sct, patt', [
     ('Ex().check_for_loop().check_body().check_for_loop().check_body().has_equal_output()',
-        'Check the first for statement. Did you correctly specify the body? Expected the output `1+1`, but got `1-1`.'),
+        'Check the first for loop. Did you correctly specify the body? Expected the output `1+1`, but got `1-1`.'),
     ('Ex().check_for_loop().check_body().check_for_loop().disable_highlighting().check_body().has_equal_output()',
-        'Check the first for statement. Did you correctly specify the body? Check the first for statement. Did you correctly specify the body? Expected the output `1+1`, but got `1-1`.')
+        'Check the first for loop. Did you correctly specify the body? Check the first for loop. Did you correctly specify the body? Expected the output `1+1`, but got `1-1`.')
 ])
 def test_limited_stacking(sct, patt):
     code = '''
@@ -463,3 +463,18 @@ Ex().check_if_else().multi(
     assert not output['correct']
     assert message(output, patt)
     if lines: helper.with_line_info(output,   *lines)
+
+## Jinja handling -------------------------------------------------------------
+
+@pytest.mark.parametrize('msgpart', [
+    "__JINJA__:You did {{stu_eval}}, but should be {{sol_eval}}!",
+    "You did {{stu_eval}}, but should be {{sol_eval}}!"
+])
+def test_jinja_in_custom_msg(msgpart):
+    output = helper.run({
+        'DC_SOLUTION': 'x = 4',
+        'DC_CODE': 'x = 3',
+        'DC_SCT': "Ex().check_object('x').has_equal_value(incorrect_msg=\"%s\")" % msgpart
+    })
+    assert not output['correct']
+    assert message(output, 'You did 3, but should be 4!')

--- a/tests/test_test_with.py
+++ b/tests/test_test_with.py
@@ -15,7 +15,7 @@ import pytest
         None
     ),
     (
-        "test_with(1, body = [test_function('print', index = i + 1) for i in range(3)], expand_message = False)",
+        "test_with(1, body = [test_function('print', index = i + 1) for i in range(3)])",
         False,
         None,
         [6, 6, 11, 16]


### PR DESCRIPTION
- `FMT:` prefix no longer supported.
- Jinja templating used for all; `__JINJA__` prefix simply removed if it's still in a custom message.
- Get rid of custom messaging in test_compound_statement --> depend on messaging from their respective`check_` functions.
- Some changes are breaking, but only require rewrite of a couple of SCTs (this is done now)

Closes #137 #299