### PR TITLE
Implement force_diagnose in test_exercise and check_correct

### DIFF
--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -49,6 +49,7 @@ class State(object):
                  student_parts=None, solution_parts=None, 
                  highlight = None,
                  highlighting_disabled = None, messages=None,
+                 force_diagnose = False,
                  **kwargs):
 
         # Set basic fields from kwargs
@@ -57,6 +58,7 @@ class State(object):
         self.student_parts = student_parts
         self.solution_parts = solution_parts
         self.messages = messages if messages else []
+        self.force_diagnose = force_diagnose
 
         # parse code if didn't happen yet
         if not hasattr(self, 'student_tree'):
@@ -194,7 +196,8 @@ class State(object):
                       highlight = highlight,
                       highlighting_disabled = highlighting_disabled,
                       messages = messages,
-                      parent_state = self)
+                      parent_state = self,
+                      force_diagnose=self.force_diagnose)
         return(child)
 
     def update(self, **kwargs):

--- a/pythonwhat/check_function.py
+++ b/pythonwhat/check_function.py
@@ -56,7 +56,7 @@ def check_function(name, index=0,
             in case the function parameters were not successfully matched.
         expand_msg (str): If specified, this overrides any messages that are prepended by previous SCT chains.
         signature (Signature): Normally, check_function() can figure out what the function signature is,
-            but it might be necessary to use build_sig to manually build a signature and pass this along.
+            but it might be necessary to use ``sig_from_params()`` to manually build a signature and pass this along.
         state (State): State object that is passed from the SCT Chain (don't specify this).
 
     :Examples:

--- a/pythonwhat/check_logic.py
+++ b/pythonwhat/check_logic.py
@@ -137,12 +137,21 @@ def check_correct(check, diagnose, state=None):
             )
 
     """
-    def diagnose_and_check(state=None):
-        # use multi twice, since diagnose and check may be lists of tests
-        multi(diagnose, state=state)
+    feedback = None
+    try:
         multi(check, state=state)
+    except TestFail as e:
+        feedback = e.feedback
 
-    check_or(diagnose_and_check, check, state=state)
+    try:
+        multi(diagnose, state=state)
+    except TestFail as e:
+        if feedback is not None or state.force_diagnose:
+            feedback = e.feedback
+
+    if feedback is not None:
+        rep = Reporter.active_reporter
+        rep.do_test(Test(feedback))
 
 # utility functions -----------------------------------------------------------
 

--- a/pythonwhat/check_syntax.py
+++ b/pythonwhat/check_syntax.py
@@ -84,6 +84,9 @@ class Chain:
         return chain
 
 class F(Chain):
+    """
+    Chain with deferred State passing
+    """
     def __init__(self, stack = None):
         self._crnt_sct = None
         self._stack = [] if stack is None else stack
@@ -100,8 +103,7 @@ class F(Chain):
     
     @classmethod
     def _from_func(cls, f):
-        func_chain = cls()
-        func_chain._stack.append(f)
+        func_chain = cls(stack = [f])
         return func_chain
 
 def Ex(state = None):

--- a/pythonwhat/check_syntax.py
+++ b/pythonwhat/check_syntax.py
@@ -46,7 +46,7 @@ def state_dec(f):
 class Chain:
     def __init__(self, state):
         self._state = state
-        self._crnt_sct = None
+        self._crnt_sct = None  # last called SCT
         self._waiting_on_call = False
 
     def _double_attr_error(self):
@@ -91,6 +91,7 @@ class F(Chain):
 
     def __call__(self, *args, **kwargs):
         if not self._crnt_sct:
+            # first function in chain
             state = kwargs.get('state') or args[0]
             return reduce(lambda s, f: f(state=s), self._stack, state)
         else:

--- a/pythonwhat/test_exercise.py
+++ b/pythonwhat/test_exercise.py
@@ -14,7 +14,8 @@ def test_exercise(sct,
                   solution_process,
                   raw_student_output,
                   ex_type,
-                  error):
+                  error,
+                  force_diagnose=False):
     """
     Point of interaction with the Python backend.
     Args:
@@ -42,7 +43,8 @@ def test_exercise(sct,
             pre_exercise_code = check_str(pre_exercise_code),
             student_process = check_process(student_process),
             solution_process = check_process(solution_process),
-            raw_student_output = check_str(raw_student_output)
+            raw_student_output = check_str(raw_student_output),
+            force_diagnose = force_diagnose
         )
 
         State.root_state = state

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -16,6 +16,7 @@ def run(data, run_code = True):
     stu_code = data.get("DC_CODE", "")
     sol_code = data.get("DC_SOLUTION", "")
     sct = data.get("DC_SCT", "")
+    force_diagnose = data.get("DC_FORCE_DIAGNOSE", False)
 
     class ChDir(object):
         """
@@ -61,6 +62,7 @@ def run(data, run_code = True):
                                 solution_process=sol_process,
                                 raw_student_output = raw_stu_output,
                                 ex_type = "NormalExercise",
+                                force_diagnose = force_diagnose,
                                 error = error)
 
     return res

--- a/tests/test_check_logic.py
+++ b/tests/test_check_logic.py
@@ -95,6 +95,22 @@ def test_check_correct(sct, passes, msg):
     if msg: assert output['message'] == msg
 
 @pytest.mark.parametrize('sct, passes, msg', [
+    ("Ex().check_correct(has_code('a'), has_code('b'))", False, None),
+    ("Ex().check_correct(has_code('a'), has_code('c'))", False, None),
+    ("Ex().check_correct(has_code('b'), has_code('c', not_typed_msg='x'))", False, 'x'),
+    ("Ex().check_correct(has_code('b', not_typed_msg='x'), has_code('a'))", False, 'x')
+])
+def test_check_correct_force_diagnose(sct, passes, msg):
+    data = {
+        'DC_CODE': "'a'",
+        'DC_SCT': sct,
+        'DC_FORCE_DIAGNOSE': True
+    }
+    output = helper.run(data)
+    assert output['correct'] == passes
+    if msg: assert output['message'] == msg
+
+@pytest.mark.parametrize('sct, passes, msg', [
     ("test_correct(lambda: test_student_typed('a'), lambda: test_student_typed('b'))", True, None),
     ("test_correct(test_student_typed('a'), test_student_typed('b'))", True, None),
     ("Ex().test_correct(has_code('a'), has_code('b'))", True, None),


### PR DESCRIPTION
Support datacamp/exercise-validator/issues/158 by accepting the `force_diagnose` parameter and using it in `check_correct`.