### PR TITLE
Use raised error information

### DIFF
--- a/pythonwhat/check_function.py
+++ b/pythonwhat/check_function.py
@@ -121,8 +121,8 @@ def check_function(name, index=0,
         try:
             sol_sig = get_sig(mapped_name=sol_parts['name'], process=state.solution_process)
             sol_parts['args'] = bind_args(sol_sig, sol_parts['args'])
-        except:
-            raise InstructorError("`check_function()` couldn't match the %s call of `%s` to its signature. " % (get_ord(index + 1), name))
+        except Exception as e:
+            raise InstructorError("`check_function()` couldn't match the %s call of `%s` to its signature:\n%s " % (get_ord(index + 1), name, e))
 
         try:
             stu_sig = get_sig(mapped_name=stu_parts['name'], process=state.student_process)

--- a/pythonwhat/tasks.py
+++ b/pythonwhat/tasks.py
@@ -111,11 +111,11 @@ def get_signature(name, mapped_name, signature, manual_sigs, env):
                         raise InstructorError('signature error - %s not in builtins' % generic_name)
                 else:
                     raise InstructorError('manual signature not found')
-        except:
+        except Exception as e:
             try:
                 signature = inspect.signature(fun)
             except:
-                raise InstructorError('signature error - cannot determine signature')
+                raise InstructorError(e.args[0] + ' and cannot determine signature')
 
     return signature
 
@@ -123,14 +123,11 @@ def get_signature(name, mapped_name, signature, manual_sigs, env):
 # Get the signature of a function based on an object inside the process
 @process_task
 def getSignatureInProcess(name, mapped_name, signature, manual_sigs, process, shell):
-    try:
-        return get_signature(name = name,
-                                mapped_name = mapped_name,
-                                signature = signature,
-                                manual_sigs = manual_sigs,
-                                env = get_env(shell.user_ns))
-    except:
-        return None
+    return get_signature(name = name,
+                         mapped_name = mapped_name,
+                         signature = signature,
+                         manual_sigs = manual_sigs,
+                         env = get_env(shell.user_ns))
 
 @process_task
 def getSignatureFromObjInProcess(obj_char, process, shell):


### PR DESCRIPTION
Currently the underlying cause is caught and the information is lost, while it can be useful for debugging.