### PR TITLE
Expose allow_errors SCT + fix using _debug

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -44,10 +44,10 @@ has_equal_x
 Combining SCTs
 --------------
 
-.. autofunction:: pythonwhat.checks.check_logic.multi
-.. autofunction:: pythonwhat.checks.check_logic.check_correct
-.. autofunction:: pythonwhat.checks.check_logic.check_or
-.. autofunction:: pythonwhat.checks.check_logic.check_not
+.. autofunction:: protowhat.checks.check_logic.multi
+.. autofunction:: protowhat.checks.check_logic.check_correct
+.. autofunction:: protowhat.checks.check_logic.check_or
+.. autofunction:: protowhat.checks.check_logic.check_not
 
 Function/Class/Lambda definitions
 ---------------------------------
@@ -95,4 +95,5 @@ Electives
 
 .. autofunction:: pythonwhat.checks.has_funcs.has_chosen
 .. autofunction:: pythonwhat.test_exercise.success_msg
-.. autofunction:: pythonwhat.checks.check_logic.fail
+.. autofunction:: protowhat.checks.check_simple.allow_errors
+.. autofunction:: protowhat.checks.check_logic.fail

--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -113,6 +113,10 @@ class State(ProtoState):
         student tree and solution tree. This is necessary when testing if statements or
         for loops for example.
         """
+        bad_pars = set(kwargs) - set(self.params)
+        if bad_pars:
+            raise ValueError("Invalid init params for State: %s" % ", ".join(bad_pars))
+
         base_kwargs = {
             attr: getattr(self, attr)
             for attr in self.params
@@ -121,7 +125,6 @@ class State(ProtoState):
 
         if not isinstance(append_message, dict):
             append_message = {"msg": append_message, "kwargs": {}}
-
         kwargs["messages"] = [*self.messages, append_message]
 
         def update_kwarg(name, func):
@@ -156,7 +159,16 @@ class State(ProtoState):
                     kwargs.pop(context)
 
         klass = self.SUBCLASSES[node_name] if node_name else State
-        child = klass(**{**base_kwargs, **kwargs})
+        init_kwargs = {**base_kwargs, **kwargs}
+        child = klass(**init_kwargs)
+
+        extra_attrs = set(vars(self).keys()) - set(self.params)
+        for attr in extra_attrs:
+            # don't copy attrs set on new instances in init
+            # the cached manual_sigs is passed
+            if attr not in ["params", "ast_dispatcher", "converters"]:
+                setattr(child, attr, getattr(self, attr))
+
         return child
 
     def has_different_processes(self):

--- a/pythonwhat/State.py
+++ b/pythonwhat/State.py
@@ -162,11 +162,11 @@ class State(ProtoState):
         init_kwargs = {**base_kwargs, **kwargs}
         child = klass(**init_kwargs)
 
-        extra_attrs = set(vars(self).keys()) - set(self.params)
+        extra_attrs = set(vars(self)) - set(self.params)
         for attr in extra_attrs:
             # don't copy attrs set on new instances in init
             # the cached manual_sigs is passed
-            if attr not in ["params", "ast_dispatcher", "converters"]:
+            if attr not in {"params", "ast_dispatcher", "converters"}:
                 setattr(child, attr, getattr(self, attr))
 
         return child

--- a/pythonwhat/checks/check_wrappers.py
+++ b/pythonwhat/checks/check_wrappers.py
@@ -1,10 +1,11 @@
 from protowhat.utils import _debug
+from protowhat.checks.check_simple import allow_errors
 from protowhat.checks.check_files import check_file, has_dir
 from pythonwhat.checks.check_funcs import check_part, check_part_index, check_node
 from pythonwhat.checks.has_funcs import has_equal_part
-from pythonwhat.checks import check_object, check_logic, check_funcs, has_funcs
 from pythonwhat.checks.check_function import check_function
 from pythonwhat.checks.check_has_context import has_context
+from pythonwhat.checks import check_object, check_logic, check_funcs, has_funcs
 from pythonwhat.local import run
 
 from inspect import signature, Parameter
@@ -771,9 +772,14 @@ for k in ["check_object", "is_instance", "check_df", "check_keys"]:
 
 scts["has_context"] = has_context
 scts["check_function"] = check_function
+
 scts["run"] = run
+
 scts["check_file"] = check_file
 scts["has_dir"] = has_dir
+
+scts["allow_errors"] = allow_errors
+
 scts["_debug"] = _debug
 
 locals().update(scts)

--- a/pythonwhat/test_exercise.py
+++ b/pythonwhat/test_exercise.py
@@ -66,7 +66,7 @@ def test_exercise(
     return state.reporter.build_final_payload()
 
 
-# TODO: consistent success_msg and allow_errors
+# TODO: consistent success_msg
 def success_msg(message):
     """
     Set the succes message of the sct. This message will be the feedback if all tests pass.
@@ -76,6 +76,7 @@ def success_msg(message):
     State.root_state.reporter.success_msg = message
 
 
+# deprecated
 def allow_errors():
     State.root_state.reporter.errors_allowed = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # pythonwhat deps
-protowhat~=1.8.3
+protowhat~=1.9.0
 asttokens~=1.1.10
 dill~=0.2.7.1
 markdown2~=2.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # pythonwhat deps
-protowhat~=1.8.2
+protowhat~=1.8.3
 asttokens~=1.1.10
 dill~=0.2.7.1
 markdown2~=2.3.7

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -43,6 +43,13 @@ def capture_test_data(f):
 test_exercise = capture_test_data(test_exercise)
 
 
+@contextmanager
+def in_temp_dir():
+    with tempfile.TemporaryDirectory() as d:
+        with ChDir(d):
+            yield
+
+
 def run(data, run_code=True):
 
     pec = data.get("DC_PEC", "")
@@ -51,30 +58,29 @@ def run(data, run_code=True):
     sct = data.get("DC_SCT", "")
     force_diagnose = data.get("DC_FORCE_DIAGNOSE", False)
 
-    with tempfile.TemporaryDirectory() as d:
-        with ChDir(d):
-            if run_code:
-                sol_process, stu_process, raw_stu_output, error = run_exercise(
-                    pec, sol_code, stu_code
-                )
-            else:
-                raw_stu_output = ""
-                stu_process = StubProcess()  # WorkerProcess()
-                sol_process = StubProcess()  # WorkerProcess()
-                error = None
-
-            res = test_exercise(
-                sct=sct,
-                student_code=stu_code,
-                solution_code=sol_code,
-                pre_exercise_code=pec,
-                student_process=stu_process,
-                solution_process=sol_process,
-                raw_student_output=raw_stu_output,
-                ex_type="NormalExercise",
-                force_diagnose=force_diagnose,
-                error=error,
+    with in_temp_dir():
+        if run_code:
+            sol_process, stu_process, raw_stu_output, error = run_exercise(
+                pec, sol_code, stu_code
             )
+        else:
+            raw_stu_output = ""
+            stu_process = StubProcess()  # WorkerProcess()
+            sol_process = StubProcess()  # WorkerProcess()
+            error = None
+
+        res = test_exercise(
+            sct=sct,
+            student_code=stu_code,
+            solution_code=sol_code,
+            pre_exercise_code=pec,
+            student_process=stu_process,
+            solution_process=sol_process,
+            raw_student_output=raw_stu_output,
+            ex_type="NormalExercise",
+            force_diagnose=force_diagnose,
+            error=error,
+        )
 
     return res
 

--- a/tests/test_check_files.py
+++ b/tests/test_check_files.py
@@ -87,7 +87,9 @@ def test_file_content(temp_file):
     expected_content = cf.get_file_content(temp_file.name)
     chain = setup_state("", "", pec="")
 
-    chain.check_file(temp_file.name, parse=False).has_code(expected_content.split("\n")[0])
+    chain.check_file(temp_file.name, parse=False).has_code(
+        expected_content.split("\n")[0]
+    )
     chain.check_file(
         temp_file.name, parse=False, solution_code=expected_content
     ).has_code(expected_content.split("\n")[0])
@@ -161,6 +163,6 @@ def test_running_file_with_root_check(temp_py_file):
 
     with tempfile.TemporaryDirectory() as d:
         with ChDir(d):
-            chain.check_file(
-                temp_py_file.name, solution_code=content
-            ).run().has_output("Hi")
+            chain.check_file(temp_py_file.name, solution_code=content).run().has_output(
+                "Hi"
+            )

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -2,6 +2,18 @@ import requests
 import tests.helper as helper
 
 
+def test_debug_on_error():
+    data = {
+        "DC_PEC": "",
+        "DC_CODE": "x = 123",
+        "DC_SOLUTION": "x = 122",
+        "DC_SCT": "Ex()._debug(on_error=True).check_object('x').has_equal_value()",
+    }
+    output = helper.run(data)
+    assert not output["correct"]
+    assert "SCT" in output["message"]
+
+
 def build_data(course_id, chapter_id, ex_number, printout=False):
     url = "https://www.datacamp.com/api/courses/{course_id}/chapters/{chapter_id}/exercises.json".format(
         course_id=course_id, chapter_id=chapter_id

--- a/tests/test_local.py
+++ b/tests/test_local.py
@@ -1,9 +1,7 @@
 import pytest
 
-from protowhat.Test import TestFail as TF
 from pythonwhat.test_exercise import setup_state
-from tests.helper import verify_sct
-
+from tests.helper import verify_sct, in_temp_dir
 
 modify_sys = (
     """
@@ -58,13 +56,14 @@ urlretrieve('{}', 'LIGO_data.hdf5')""".format(
 def test_urlretrieve_in_process(sol_code, stu_code):
     # on mac an env var needs to be set:
     # OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-    chain = setup_state("", "", pec="")
+    with in_temp_dir():
+        chain = setup_state("", "", pec="")
 
-    chain._state.solution_code = sol_code
-    chain._state.student_code = stu_code
+        chain._state.solution_code = sol_code
+        chain._state.student_code = stu_code
 
-    with verify_sct(True):
-        chain.run()
+        with verify_sct(True):
+            chain.run()
 
 
 @pytest.mark.parametrize(
@@ -82,10 +81,11 @@ with urllib.request.urlopen({}) as response, open('LIGO_data.hdf5', 'wb') as out
     ],
 )
 def test_urlopen_in_process(sol_code, stu_code):
-    chain = setup_state("", "", pec="")
+    with in_temp_dir():
+        chain = setup_state("", "", pec="")
 
-    chain._state.solution_code = sol_code
-    chain._state.student_code = stu_code
+        chain._state.solution_code = sol_code
+        chain._state.student_code = stu_code
 
-    with verify_sct(True):
-        chain.run()
+        with verify_sct(True):
+            chain.run()


### PR DESCRIPTION
- Expose `allow_errors`: https://github.com/datacamp/protowhat/pull/37
- Pass non-constructor-controlable attributes to child states as in protowhat
  - This makes `_debug(on_error=True)` work, which sets the `_debug` attribute
  - I added a test