### PR TITLE
Add templated expr_code

### DIFF
--- a/pythonwhat/checks/has_funcs.py
+++ b/pythonwhat/checks/has_funcs.py
@@ -230,11 +230,12 @@ args_string = """
           You can also use ``set_context()`` for this.
         pre_code (str): the code in string form that should be executed before the expression is executed.
           This is the ideal place to set a random seed, for example.
-        expr_code (str): if this argument is set, the expression in the student/solution code will not
+        expr_code (str): If this argument is set, the expression in the student/solution code will not
           be ran. Instead, the given piece of code will be ran in the student as well as the solution environment
-          and the result will be compared.
+          and the result will be compared. However if the string contains one or more placeholders ``__focus__``,
+          they will be substituted by the currently focused code.
         name (str): If this is specified, the {0} of running this expression after running the focused expression
-          is returned, instead of the {0} of the focussed expression in itself. This is typically used to inspect the
+          is returned, instead of the {0} of the focused expression in itself. This is typically used to inspect the
           {0} of an object after executing the body of e.g. a ``for`` loop.
         copy (bool): whether to try to deep copy objects in the environment, such as lists, that could
           accidentally be mutated. Disable to speed up SCTs. Disabling may lead to cryptic mutation issues.
@@ -281,6 +282,9 @@ def has_expr(
             error_msg = DEFAULT_ERROR_MSG_INV
         else:
             error_msg = DEFAULT_ERROR_MSG
+
+    if state.solution_code is not None and isinstance(expr_code, str):
+        expr_code = expr_code.replace("__focus__", state.solution_code)
 
     get_func = partial(
         evalCalls[test],

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -789,7 +789,7 @@ for i in range(2):
     assert message(output, patt)
 
 
-## test has_expr --------------------------------------------------------------
+# test has_expr --------------------------------------------------------------
 
 
 @pytest.mark.parametrize(
@@ -815,7 +815,45 @@ def test_has_expr(sct, patt):
     assert message(output, patt)
 
 
-## check_if_else --------------------------------------------------------------
+def test_has_expr_replace_focus():
+    # Given
+    sct = "Ex().check_if_else().check_test().has_equal_value(expr_code = '__focus__ == \\'valid\\'')"
+    feedback_msg = "Great work!"
+
+    # When
+    output = helper.run(
+        {
+            "DC_SOLUTION": "u = 'valid'\nif u:\n  print('')",
+            "DC_CODE": "u = 'valid'\nif u:\n  print('')",
+            "DC_SCT": sct,
+        }
+    )
+
+    # Then
+    assert output["correct"]
+    assert message(output, feedback_msg)
+
+
+def test_has_expr_replace_focus_fail():
+    # Given
+    sct = "Ex().check_if_else().check_test().has_equal_value(expr_code = '__focus__ == \\'valid\\'')"
+    feedback_msg = "Check the first if statement. Did you correctly specify the condition? Running the expression <code>u == 'valid'</code> didn't generate the expected result."  # nopep8
+
+    # When
+    output = helper.run(
+        {
+            "DC_SOLUTION": "u = 'valid'\nif u:\n  print('')",
+            "DC_CODE": "u = 'wrong'\nif u:\n  print('')",
+            "DC_SCT": sct,
+        }
+    )
+
+    # Then
+    assert not output["correct"]
+    assert message(output, feedback_msg)
+
+
+# check_if_else --------------------------------------------------------------
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
It would be useful to be able to use the zoomed code in expr_code. We decided to use string replace on "\_\_focus\_\_" instead of using format. Using format would not allow the use of {} anywhere in expr_code. 
"\_\_focus\_\_ "is also replaced in the feedback message.

Usage: `expr_code="list(__focus__)"`

Todo: Add usage to pyhtonwhat docs