### PR TITLE
[LO-827] Fix/has-expr-string-formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the pythonwhat project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## 2.23.1
+
+- Fix string formatting in has_expr(). Strings will now have quotes in error messages. Leading and trailing whitespace is no longer removed.
+
 ## 2.23.0
 
 - Update to protowhat v2 (embedding xwhats, `prepare_validation` helper,  for checking bash history, autodebug)

--- a/pythonwhat/__init__.py
+++ b/pythonwhat/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.23.0"
+__version__ = "2.23.1"
 
 from .test_exercise import test_exercise, allow_errors

--- a/pythonwhat/checks/has_funcs.py
+++ b/pythonwhat/checks/has_funcs.py
@@ -339,13 +339,24 @@ def has_expr(
         "expr_code": expr_code,
     }
 
-    fmt_kwargs["stu_eval"] = utils.shorten_str(str(eval_stu))
-    fmt_kwargs["sol_eval"] = utils.shorten_str(str(eval_sol))
+    fmt_kwargs["stu_eval"] = str(eval_stu)
+    fmt_kwargs["sol_eval"] = str(eval_sol)
+
+    # wrap in quotes if eval_sol or eval_stu are strings
+    if test == "value":
+        if isinstance(eval_stu, str):
+            fmt_kwargs["stu_eval"] = '\'{}\''.format(fmt_kwargs["stu_eval"])
+        if isinstance(eval_sol, str):
+            fmt_kwargs["sol_eval"] = '\'{}\''.format(fmt_kwargs["sol_eval"])
+
+    # check if student or solution evaluations are too long or contain newlines
     if incorrect_msg == DEFAULT_INCORRECT_MSG and (
-        fmt_kwargs["stu_eval"] is None
-        or fmt_kwargs["sol_eval"] is None
+        utils.unshowable_string(fmt_kwargs["stu_eval"])
+        or utils.unshowable_string(fmt_kwargs["sol_eval"])
         or fmt_kwargs["stu_eval"] == fmt_kwargs["sol_eval"]
     ):
+        fmt_kwargs["stu_eval"] = None
+        fmt_kwargs["sol_eval"] = None
         incorrect_msg = "Expected something different."
 
     # tests ---

--- a/pythonwhat/utils.py
+++ b/pythonwhat/utils.py
@@ -11,10 +11,8 @@ def v2_only():
     return not include_v1()
 
 
-def shorten_str(text, to_chars=100):
-    if "\n" in text or len(text) > 50:
-        return None
-    return text
+def unshowable_string(text):
+    return "\n" in text or len(text) > 50
 
 
 def copy_env(env):

--- a/tests/test_messaging.py
+++ b/tests/test_messaging.py
@@ -532,7 +532,7 @@ Ex().check_function_def('test').multi(
     [
         (
             "echo_word = (lambda word1, echo: word1 * echo * 2)",
-            "Check the first lambda function. To verify it, we reran it with the arguments `('test', 2)`. Expected `testtest`, but got `testtesttesttest`.",
+            "Check the first lambda function. To verify it, we reran it with the arguments `('test', 2)`. Expected `'testtest'`, but got `'testtesttesttest'`.",
         )
     ],
 )
@@ -694,6 +694,53 @@ def test_has_equal_x_2(stu, patt, cols, cole):
     assert message(output, patt)
     assert lines(output, cols, cole)
 
+
+def test_has_equal_value_wrap_string():
+    sol = """print(' , ')"""
+    stu = """print(', ')"""
+    sct = """Ex().check_function('print', index=0, signature=False).check_args(0).has_equal_value(copy = False)"""
+    output = helper.run(
+        {
+            "DC_CODE": stu,
+            "DC_SOLUTION": sol,
+            "DC_SCT": sct,
+        }
+    )
+    assert not output["correct"]
+    assert output["message"] == "Check your call of <code>print()</code>. Did you correctly specify the first argument? Expected <code>' , '</code>, but got <code>', '</code>."  # nopep8
+
+
+## Testing output edge cases -------------------------------------------------
+
+
+def test_has_equal_value_dont_wrap_newline():
+    sol = """print('\\n')"""
+    stu = """print('text')"""
+    sct = """Ex().check_function('print', index=0, signature=False).check_args(0).has_equal_value()"""
+    output = helper.run(
+        {
+            "DC_CODE": stu,
+            "DC_SOLUTION": sol,
+            "DC_SCT": sct,
+        }
+    )
+    assert not output["correct"]
+    assert output["message"] == "Check your call of <code>print()</code>. Did you correctly specify the first argument? Expected something different."  # nopep8
+
+
+def test_has_equal_value_dont_wrap_too_long():
+    sol = """print('short text')"""
+    stu = """print('This text is longer than 50 characters if I copy it 3 times. This text is longer than 50 characters if I copy it 3 times. This text is longer than 50 characters if I copy it 3 times.')"""  # nopep8
+    sct = """Ex().check_function('print', index=0, signature=False).check_args(0).has_equal_value()"""
+    output = helper.run(
+        {
+            "DC_CODE": stu,
+            "DC_SOLUTION": sol,
+            "DC_SCT": sct,
+        }
+    )
+    assert not output["correct"]
+    assert output["message"] == "Check your call of <code>print()</code>. Did you correctly specify the first argument? Expected something different."  # nopep8
 
 ## Check has no error ---------------------------------------------------------
 


### PR DESCRIPTION
- Fixed issue with error message not showing quotes if the output was a string
- Improved clarity of functions in utils.py
- Added tests to test for edge cases with newlines and strings in test_messaging.py
- Failed seven exercises, all working when tested manually. See: https://app.circleci.com/pipelines/github/datacamp-engineering/shared-images/380/workflows/997861c1-6b91-4d2b-8a86-504e2ee240ee/jobs/720