### PR TITLE
fix: ci config regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,12 +29,15 @@ jobs:
 workflows:
   build:
     jobs:
-      - build-and-test
+      - build-and-test:
+          filters:
+            tags:
+              only: /^v\d+\.\d+\.\d+$/
       - publish:
           requires:
             - build-and-test
           filters:
             tags:
-              only: /^v\d+\.\d+\.\d+(-rc\.\d+)?$/
+              only: /^v\d+\.\d+\.\d+$/
             branches:
               ignore: /.*/


### PR DESCRIPTION
- Add tag filter to `build-and-test` job because it is a requirement for the `publish` job
- Changed the tag filter regex to not match on rc tags since we do not use them for this project