### PR TITLE
docs: cleanup: remove redundant sphinxprettysearchresults Sphinx extension

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,6 @@ extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinxcontrib.jinja",
-    "sphinxprettysearchresults",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,3 @@ pytest-cov~=2.12.1
 sphinx~=4.1.2
 sphinx_rtd_theme~=0.5.2
 sphinx-jinja~=1.1.1
-sphinxprettysearchresults~=0.3.5


### PR DESCRIPTION
This extension served as a workaround for non-ideal search result formatting in Sphinx versions earlier than v2.0.0 and is no longer required.

See https://github.com/sphinx-doc/sphinx/issues/1618 for the original issue (and https://github.com/sphinx-doc/sphinx/pull/4022 for the fixup).