### PR TITLE
[CP-3517] chore: fix typo's, use raw strings, update varnames

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,12 @@ workflows:
   build:
     jobs:
       - build-and-test:
+          context: org-global
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+$/
       - publish:
+          context: org-global
           requires:
             - build-and-test
           filters:

--- a/pythonwhat/checks/has_funcs.py
+++ b/pythonwhat/checks/has_funcs.py
@@ -579,7 +579,7 @@ def has_import(
 
 
 def has_output(state, text, pattern=True, no_output_msg=None):
-    """Search student output for a pattern.
+    r"""Search student output for a pattern.
 
     Among the student and solution process, the student submission and solution code as a string,
     the ``Ex()`` state also contains the output that a student generated with his or her submission.

--- a/pythonwhat/sct_syntax.py
+++ b/pythonwhat/sct_syntax.py
@@ -19,7 +19,7 @@ def multi_dec(f):
             args[0] if len(args) == 1 and isinstance(args[0], (list, tuple)) else args
         )
         for arg in args:
-            if isinstance(arg, Node) and arg.parent.name is "root":
+            if isinstance(arg, Node) and arg.parent.name == "root":
                 arg.parent.remove_child(arg)
                 arg.update_child_calls()
         return f(*args, **kwargs)

--- a/pythonwhat/tasks.py
+++ b/pythonwhat/tasks.py
@@ -370,7 +370,7 @@ def taskRunEval(
     Args:
         tree (ast): current focused ast, used to get code to execute
         process: manages shell (see local.py)
-        shell: link to to get process namespace from execution up until now
+        shell: link to get process namespace from execution up until now
         env: update value in focused code by name
         extra_env: variables to be replaced in focused code by name from extra_env in has_expr
         context: sum of set_context in sct chain

--- a/pythonwhat/test_exercise.py
+++ b/pythonwhat/test_exercise.py
@@ -22,7 +22,7 @@ def test_exercise(
     """
     Point of interaction with the Python backend.
     Args:
-            sct (str): The solution corectness test as a string of code.
+            sct (str): The solution correctness test as a string of code.
             student_code (str): The code which is entered by the student.
             solution_code (str): The code which is in the solution.
             pre_exercise_code (str): The code which is executed pre exercise.
@@ -73,7 +73,7 @@ def test_exercise(
 # TODO: consistent success_msg
 def success_msg(message):
     """
-    Set the succes message of the sct. This message will be the feedback if all tests pass.
+    Set the success message of the sct. This message will be the feedback if all tests pass.
     Args:
             message (str): A string containing the feedback message.
     """

--- a/pythonwhat/utils.py
+++ b/pythonwhat/utils.py
@@ -1,10 +1,9 @@
 from types import ModuleType
 import copy
 import os
-import black
-
 
 def format_code(text):
+    import black
     mode = black.FileMode()
     try:
         return black.format_file_contents(text, fast=True, mode=mode).rstrip()

--- a/tests/test_has_output.py
+++ b/tests/test_has_output.py
@@ -4,42 +4,42 @@ from pythonwhat.test_exercise import setup_state
 
 
 @pytest.mark.parametrize(
-    "stu, passes",
+    "student_code, passes",
     [
         ('print("Hi, there!")', True),
         ('print("hi  there!")', True),
         ('print("Hello there")', False),
     ],
 )
-def test_has_output_basic(stu, passes):
-    s = setup_state(stu, "")
+def test_has_output_basic(student_code, passes):
+    s = setup_state(student_code, "")
     with helper.verify_sct(passes):
         s.has_output(r"[H|h]i,*\s+there!")
 
 
 @pytest.mark.parametrize(
-    "stu, passes",
+    "student_code, passes",
     [
         ('print("Hi, there!")', True),
         ('print("hi  there!")', False),
         ('print("Hello there")', False),
     ],
 )
-def test_has_output_pattern(stu, passes):
-    s = setup_state(stu, "")
+def test_has_output_pattern(student_code, passes):
+    s = setup_state(student_code, "")
     with helper.verify_sct(passes):
         s.has_output("Hi, there!", pattern=False)
 
 
 @pytest.mark.parametrize(
-    "stu, passes",
+    "student_code, passes",
     [
         ('print("Hi, there!")', True),
         ('print("hi  there!")', True),
         ('print("Hello there")', False),
     ],
 )
-def test_test_output_contains(stu, passes):
-    s = setup_state(stu, "")
+def test_test_output_contains(student_code, passes):
+    s = setup_state(student_code, "")
     with helper.verify_sct(passes):
         s.test_output_contains(r"[H|h]i,*\s+there!")


### PR DESCRIPTION
Fixes https://datacamp.atlassian.net/browse/CP-3517

Strictly, only the change to raw strings for some docstrings is necessary. Also fixed some typos, and renamed a test variable for clarity.