### PR TITLE
[CP-3517] chore: fix failing test

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -10,6 +10,7 @@ seaborn~=0.11.2
 sqlalchemy~=1.4.23
 xlrd~=2.0.1
 openpyxl~=3.0.7
+h5py~=3.11.0
 
 # test-utils deps
 pytest~=6.2.5

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -51,7 +51,6 @@ def in_temp_dir():
 
 
 def run(data, run_code=True):
-
     pec = data.get("DC_PEC", "")
     stu_code = data.get("DC_CODE", "")
     sol_code = data.get("DC_SOLUTION", "")


### PR DESCRIPTION
An earlier commit removed the h5py dependency, but it's need for this test.