### PR TITLE
[CP-3513] feat: lazy import pandas

### DIFF
--- a/pythonwhat/Test.py
+++ b/pythonwhat/Test.py
@@ -1,7 +1,5 @@
 import re
 import numpy as np
-import pandas as pd
-from pandas.testing import assert_frame_equal, assert_series_equal
 from pythonwhat.tasks import *
 from protowhat.Test import Test
 
@@ -111,6 +109,8 @@ def areinstance(x, y, tuple_of_classes):
 # First try to the faster equality functions. If these don't pass,
 # Run the assertions that are typically slower.
 def is_equal(x, y):
+    import pandas as pd
+    from pandas.testing import assert_frame_equal, assert_series_equal
     try:
         if areinstance(x, y, (Exception,)):
             # Types of errors don't matter (this is debatable)

--- a/pythonwhat/__init__.py
+++ b/pythonwhat/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.25.0"
+__version__ = "2.26.0"
 
 from .test_exercise import test_exercise, allow_errors

--- a/pythonwhat/checks/check_object.py
+++ b/pythonwhat/checks/check_object.py
@@ -13,7 +13,6 @@ from pythonwhat.tasks import (
 )
 from pythonwhat.checks.check_funcs import part_to_child
 from pythonwhat.utils import v2_only
-import pandas as pd
 import ast
 
 
@@ -289,6 +288,7 @@ def check_df(state, index, missing_msg=None, not_instance_msg=None, expand_msg=N
             my_df = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]})
 
     """
+    import pandas as pd
     child = check_object(
         state,
         index,


### PR DESCRIPTION
Importing pandas is relatively slow and a major part of the work of importing `pythonwhat` inside `pyodide`. 

When we start using this in regular sessions, this could make the sessions a tiny bit slower. To prevent that, we can start adding a special block that just runs `import pandas as pd` but only for regular sessions.