### PR TITLE
[CP-4659] feat: drop direct dependency on numpy and pandas

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,3 +15,7 @@ h5py~=3.11.0
 # test-utils deps
 pytest~=6.2.5
 pytest-cov~=2.12.1
+
+# not included in requirements.txt
+numpy~=1.26.0
+pandas~=1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,3 @@ jinja2~=3.1.3
 markupsafe==2.1.5
 black==19.10b0
 Pygments==2.13.0
-
-numpy~=1.26.0
-pandas~=1.5.3

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from setuptools import setup
 
 PACKAGE_NAME = "pythonwhat"
 REQUIREMENT_NAMES = ["protowhat", "markdown2", "jinja2", "asttokens", "dill"]
-PEER_REQUIREMENTS = ["numpy", "pandas"]
 
 HERE = path.abspath(path.dirname(__file__))
 VERSION_FILE = path.join(HERE, PACKAGE_NAME, "__init__.py")
@@ -23,7 +22,7 @@ with open(REQUIREMENTS_FILE, encoding="utf-8") as fp:
     REQUIREMENTS = [
         re.search(_requirements_re_template.format(requirement), req_txt, re.M).group(0)
         for requirement in REQUIREMENT_NAMES
-    ] + PEER_REQUIREMENTS
+    ]
 with open(README_FILE, encoding="utf-8") as fp:
     README = fp.read()
 


### PR DESCRIPTION
Part of https://datacamp.atlassian.net/browse/CP-4659

This makes numpy and pandas no longer required dependencies, meaning that they won't be automatically installed when installing pythonwhat.

The only usage of any of them on anything other than comparing numpy/pandas objects (i.e. expected usage without the need to have those packages already imported anyway) is a `np.testing.assert_equal(x, y)` to compare `dict`, `list` and `tuple` objects, and a `np.array_equal(list(x), list(y))` to compare `map` and `filter` objects. Those calls got refactored to not need numpy to achieve the same behavior.

With this change, users who relied on the instance of numpy and/or pandas installed by pythonwhat now need to install it themselves. This shouldn't affect most users, as it's good practice to always install one's own dependencies instead of having to rely on having them installed by other dependencies.