### PR TITLE
[CP-4785] Add support for Python 3.12

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build-and-test:
     docker:
-      - image: cimg/python:3.9
+      - image: cimg/python:3.12
     steps:
       - checkout
       - python/install-packages:

--- a/README.md
+++ b/README.md
@@ -53,16 +53,15 @@ To learn how to include an SCT in a DataCamp course, visit https://instructor-su
 ## Run tests
 
 ```bash
-pyenv local 3.9.6
-pip3.9 install -r requirements-test.txt
-pip3.9 install -e .
+pyenv local 3.12.7
+pip3.12 install -r requirements-test.txt
+pip3.12 install -e .
 pytest
 ```
 
 ## Contributing
 
 Bugs? Questions? Suggestions? [Create an issue](https://github.com/datacamp/pythonwhat/issues/new), or [contact us](mailto:content-engineering@datacamp.com)!
-
 
 ## License
 

--- a/pythonwhat/__init__.py
+++ b/pythonwhat/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.29.0"
+__version__ = "2.30.0"
 
 from .test_exercise import test_exercise, allow_errors

--- a/pythonwhat/checks/check_object.py
+++ b/pythonwhat/checks/check_object.py
@@ -354,7 +354,7 @@ def check_keys(state, key, missing_msg=None, expand_msg=None):
 
     def get_part(name, key, highlight):
         if isinstance(key, str):
-            slice_val = ast.Str(s=key)
+            slice_val = ast.Constant(value=key)
         else:
             slice_val = ast.parse(str(key)).body[0].value
         expr = ast.Subscript(

--- a/pythonwhat/local.py
+++ b/pythonwhat/local.py
@@ -29,7 +29,7 @@ class StubShell:
 class StubProcess:
     def __init__(self, init_code=None, pid=None):
         self.shell = StubShell(init_code)
-        self._identity = (pid,) if pid else (random.randint(0, 1e12),)
+        self._identity = (pid,) if pid else (random.randint(0, int(1e12)),)
 
     def executeTask(self, task):
         return task(self.shell)
@@ -73,7 +73,7 @@ class WorkerProcess(Process):
         )  # when parent process is killed, sub/childprocess get also killed
         self.instances.append(self)
         # used to detect single process exercise
-        self._identity = (pid,) if pid else (random.randint(0, 1e12),)
+        self._identity = (pid,) if pid else (random.randint(0, int(1e12)),)
 
     def get_shell(self):
         return create({})

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,21 +1,20 @@
 -r requirements.txt
 
 # test deps
-scipy~=1.13.1
+scipy~=1.14.1
 bs4~=0.0.1
 html5lib~=1.1
-# h5py~=3.1.0
-requests~=2.26.0
+requests~=2.31.0
 seaborn~=0.11.2
-sqlalchemy~=1.4.23
+sqlalchemy~=2.0.29
 xlrd~=2.0.1
-openpyxl~=3.0.7
-h5py~=3.11.0
+openpyxl~=3.1.0
+h5py~=3.12.1
 
 # test-utils deps
-pytest~=6.2.5
-pytest-cov~=2.12.1
+pytest~=8.1.1
+pytest-cov~=6.1.1
 
 # not included in requirements.txt
-numpy~=1.26.0
-pandas~=1.5.3
+numpy~=2.0.2
+pandas~=2.2.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,6 @@
 protowhat~=2.2.0
 asttokens~=2.4.1
 dill~=0.3.4
-markdown2~=2.4.13
+markdown2~=2.5.3
 jinja2~=3.1.3
-markupsafe==2.1.5
 black==19.10b0
-Pygments==2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # pythonwhat deps
-protowhat~=2.2.0
+protowhat~=2.3.1
 asttokens~=2.4.1
 dill~=0.3.4
 markdown2~=2.5.3

--- a/tests/test_check_function.py
+++ b/tests/test_check_function.py
@@ -92,11 +92,11 @@ def test_bind_args():
     ][0]["args"]
     sig = signature(my_fun)
     bound_args = bind_args(sig, args)
-    assert bound_args["a"]["node"].n == 1
-    assert bound_args["b"]["node"].n == 2
-    assert bound_args["args"][0]["node"].n == 3
-    assert bound_args["args"][1]["node"].n == 4
-    assert bound_args["kwargs"]["c"]["node"].n == 5
+    assert bound_args["a"]["node"].value == 1
+    assert bound_args["b"]["node"].value == 2
+    assert bound_args["args"][0]["node"].value == 3
+    assert bound_args["args"][1]["node"].value == 4
+    assert bound_args["kwargs"]["c"]["node"].value == 5
 
 
 @pytest.mark.parametrize("argspec", [["args", 0], ["args", 1], ["kwargs", "c"]])


### PR DESCRIPTION
https://datacamp.atlassian.net/browse/CP-4785

Blocked by https://github.com/datacamp/protowhat/pull/63

- Updates documentation to instruct to use Python 3.12.7
- Updates CI to run on Python 3.12
- Updates dependencies
- Resolves deprecation warnings
- Fixes an incompatibility with `random.randint`