### PR TITLE
[CP-4791] Fix typed signature validation

### DIFF
--- a/pythonwhat/tasks.py
+++ b/pythonwhat/tasks.py
@@ -134,7 +134,8 @@ def get_signature(name, mapped_name, signature, manual_sigs, env):
             except:
                 raise InstructorError.from_message(e.args[0] + " and cannot determine signature")
 
-    return signature
+    params = [param.replace(annotation=inspect._empty) for param in signature.parameters.values()]
+    return signature.replace(parameters=params)
 
 
 # Get the signature of a function based on an object inside the process


### PR DESCRIPTION
Unblocks https://datacamp.atlassian.net/browse/CP-4791

When getting typed signatures like this one from `dash`'s `dcc.Graph`:

```py
(id: Union[str, dict, NoneType] = None, responsive: Optional[Literal[True, False, 'auto']] = None, clickData: Optional[dict] = None, clickAnnotationData: Optional[dict] = None, hoverData: Optional[dict] = None, clear_on_unhover: Optional[bool] = None, selectedData: Optional[dict] = None, relayoutData: Optional[dict] = None, extendData: Union[Sequence, dict, NoneType] = None, prependData: Union[Sequence, dict, NoneType] = None, restyleData: Optional[Sequence] = None, figure: Union[plotly.graph_objs._figure.Figure, dict, NoneType] = None, style: Optional[Any] = None, className: Optional[str] = None, mathjax: Optional[bool] = None, animate: Optional[bool] = None, animation_options: Optional[dict] = None, config: Optional[ForwardRef('Config')] = None, **kwargs)
```

multiprocessing queues would error trying to pickle the resulting object:

```
 Traceback (most recent call last):
   File "/usr/lib/python3.12/multiprocessing/queues.py", line 264, in _feed
     obj = _ForkingPickler.dumps(obj)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
   File "/usr/lib/python3.12/multiprocessing/reduction.py", line 51, in dumps
     cls(buf, protocol).dump(obj)
 TypeError: cannot pickle code objects
```

The simplest solution is to strip the types from the typed signature, so that in the example above, we get:

```py
(id=None, responsive=None, clickData=None, clickAnnotationData=None, hoverData=None, clear_on_unhover=None, selectedData=None, relayoutData=None, extendData=None, prependData=None, restyleData=None, figure=None, style=None, className=None, mathjax=None, animate=None, animation_options=None, config=None, **kwargs)
```

With this signature stripped from types, we no longer get that TypeError trying to pickle code objects.