### PR TITLE
[CP-4790] Fix dill issue on Python3.12

### DIFF
--- a/pythonwhat/__init__.py
+++ b/pythonwhat/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "2.30.0"
+__version__ = "2.30.1"
 
 from .test_exercise import test_exercise, allow_errors

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # pythonwhat deps
 protowhat~=2.3.1
 asttokens~=2.4.1
-dill~=0.3.4
+dill~=0.4.0
 markdown2~=2.5.3
 jinja2~=3.1.3
 black==19.10b0


### PR DESCRIPTION
Fixes https://datacamp.atlassian.net/browse/CP-4790

Outdated versions of dill, under certain conditions, throw the following exception in newer (> 3.9) Python versions:

```
TypeError: code() argument 13 must be str, not int
```

This is fixed in newer versions of dill.